### PR TITLE
Add styles and mixins

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,5 +11,9 @@
 	"main": [
 		"main.scss",
 		"main.js"
-	]
+	],
+	"dependencies": {
+	  "o-colors": "^4.7.7",
+	  "o-icons": "^5.8.0"
+	}
 }

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,8 @@
 		"main.js"
 	],
 	"dependencies": {
-	  "o-colors": "^4.7.7",
-	  "o-icons": "^5.8.0"
+		"o-colors": "^4.7.7",
+		"o-icons": "^5.8.0",
+		"o-typography": "^5.7.8"
 	}
 }

--- a/demos/src/data/html-labels.json
+++ b/demos/src/data/html-labels.json
@@ -1,0 +1,19 @@
+{
+	"steps": [
+		{
+			"label": "Step with icon <span class=\"edit-icon\"><!-- See demo SCSS for implementation --></span>",
+			"accessibleLabel": "Step with icon",
+			"url": "#edit",
+			"isComplete": true
+		},
+		{
+			"label": "Step with<br/>multiple</br>line breaks",
+			"accessibleLabel": "Step with multiple line breaks",
+			"isCurrent": true
+		},
+		{
+			"label": "Step with <strong>bold</strong> and <em>italic</em> text",
+			"accessibleLabel": "Step with bold and italic text"
+		}
+	]
+}

--- a/demos/src/data/html-labels.json
+++ b/demos/src/data/html-labels.json
@@ -1,7 +1,7 @@
 {
 	"steps": [
 		{
-			"label": "Step with icon <span class=\"edit-icon\"><!-- See demo SCSS for implementation --></span>",
+			"label": "Step with icon <i class=\"o-icons-icon o-icons-icon--edit\" style=\"width: 20px; height: 20px; vertical-align: middle;\"><!-- Inline styles here should be in CSS or SCSS files when implementing --></i>",
 			"accessibleLabel": "Step with icon",
 			"url": "#edit",
 			"isComplete": true

--- a/demos/src/data/renewal-timeline.json
+++ b/demos/src/data/renewal-timeline.json
@@ -1,0 +1,24 @@
+{
+	"modifierClasses": "o-stepped-progress--heavy",
+	"steps": [
+		{
+			"label": "<strong>Contract start date</strong><br/> 22 Jan 2018",
+			"accessibleLabel": "Contract start date, 22 Jan 2018",
+			"isComplete": true
+		},
+		{
+			"label": "<strong>Planning meeting</strong><br/> 22 Feb 2018",
+			"accessibleLabel": "Planning meeting, 22 Feb 2018",
+			"isComplete": true
+		},
+		{
+			"label": "<strong>Mid-year review</strong><br/> 22 June 2018",
+			"accessibleLabel": "Mid-year review, 22 June 2018",
+			"isCurrent": true
+		},
+		{
+			"label": "<strong>Renewal</strong><br/> 22 Nov 2018",
+			"accessibleLabel": "Renewal, 22 Nov 2018"
+		}
+	]
+}

--- a/demos/src/data/signup-form-error.json
+++ b/demos/src/data/signup-form-error.json
@@ -1,0 +1,26 @@
+{
+	"steps": [
+		{
+			"label": "Details",
+			"accessibleLabel": "Details",
+			"url": "#details",
+			"isComplete": true
+		},
+		{
+			"label": "Delivery",
+			"accessibleLabel": "Delivery",
+			"url": "#delivery",
+			"isComplete": true
+		},
+		{
+			"label": "Customise",
+			"accessibleLabel": "Customise",
+			"url": "#customise",
+			"isError": true
+		},
+		{
+			"label": "Payment",
+			"accessibleLabel": "Payment"
+		}
+	]
+}

--- a/demos/src/data/signup-form.json
+++ b/demos/src/data/signup-form.json
@@ -1,0 +1,26 @@
+{
+	"steps": [
+		{
+			"label": "Details",
+			"accessibleLabel": "Details",
+			"url": "#details",
+			"isComplete": true
+		},
+		{
+			"label": "Delivery",
+			"accessibleLabel": "Delivery",
+			"url": "#delivery",
+			"isComplete": true
+		},
+		{
+			"label": "Customise",
+			"accessibleLabel": "Customise",
+			"url": "#customise",
+			"isCurrent": true
+		},
+		{
+			"label": "Payment",
+			"accessibleLabel": "Payment"
+		}
+	]
+}

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -1,0 +1,19 @@
+
+<div class="o-stepped-progress{{#modifierClasses}} {{modifierClasses}}{{/modifierClasses}}" data-o-component="o-stepped-progress">
+	<ol class="o-stepped-progress__steps">
+		{{#steps}}
+		<li>
+			{{#url}}
+			<a href="{{url}}" class="o-stepped-progress__step{{#isComplete}} o-stepped-progress__step--complete{{/isComplete}}{{#isCurrent}} o-stepped-progress__step--current{{/isCurrent}}{{#isError}} o-stepped-progress__step--error{{/isError}}">
+				<span class="o-stepped-progress__label"{{#isComplete}} aria-label="Completed: {{accessibleLabel}}"{{/isComplete}}{{#isCurrent}} aria-label="Current step: {{accessibleLabel}}"{{/isCurrent}}{{#isError}} aria-label="Error: {{accessibleLabel}}"{{/isError}}>{{{label}}}</span>
+			</a>
+			{{/url}}
+			{{^url}}
+			<span class="o-stepped-progress__step{{#isComplete}} o-stepped-progress__step--complete{{/isComplete}}{{#isCurrent}} o-stepped-progress__step--current{{/isCurrent}}{{#isError}} o-stepped-progress__step--error{{/isError}}">
+				<span class="o-stepped-progress__label"{{#isComplete}} aria-label="Completed: {{accessibleLabel}}"{{/isComplete}}{{#isCurrent}} aria-label="Current step: {{accessibleLabel}}"{{/isCurrent}}{{#isError}} aria-label="Error: {{accessibleLabel}}"{{/isError}}>{{{label}}}</span>
+			</span>
+			{{/url}}
+		</li>
+		{{/steps}}
+	</ol>
+</div>

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -15,12 +15,3 @@ body {
 .demo-container:last-of-type {
 	margin-bottom: 0;
 }
-
-.edit-icon {
-	@include oIconsGetIcon(
-		$icon-name: 'edit',
-		$container-width: 20px,
-		$color: #000
-	);
-	vertical-align: middle;
-}

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -12,7 +12,15 @@ body {
 	margin-bottom: 2em;
 	max-width: 600px;
 }
-.demo-container:last-child {
+.demo-container:last-of-type {
 	margin-bottom: 0;
 }
 
+.edit-icon {
+	@include oIconsGetIcon(
+		$icon-name: 'edit',
+		$container-width: 20px,
+		$color: #000
+	);
+	vertical-align: middle;
+}

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -10,6 +10,9 @@ body {
 
 .demo-container {
 	margin-bottom: 2em;
-	max-width: 600px; // TODO remove
+	max-width: 600px;
+}
+.demo-container:last-child {
+	margin-bottom: 0;
 }
 

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -2,3 +2,14 @@
 $o-stepped-progress-is-silent: false;
 
 @import '../../main';
+
+body {
+	@include oColorsFor('page', 'background');
+	margin: 1em;
+}
+
+.demo-container {
+	margin-bottom: 2em;
+	max-width: 600px; // TODO remove
+}
+

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -1,4 +1,68 @@
 
-<div>
-	<!-- TODO -->
+<div class="demo-container">
+
+	<div class="o-stepped-progress" data-o-component="o-stepped-progress">
+		<ol class="o-stepped-progress__steps">
+			<li>
+				<a href="https://www.ft.com/" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label" aria-label="Completed: Example">Example</span>
+				</a>
+			</li>
+			<li>
+				<a href="https://www.ft.com/" class="o-stepped-progress__step o-stepped-progress__step--error">
+					<span class="o-stepped-progress__label" aria-label="Error: Example">Example</span>
+				</a>
+			</li>
+			<li>
+				<a href="./pa11y.html" class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label" aria-label="Current step: Example">Example</span>
+				</a>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Example</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Example</span>
+				</span>
+			</li>
+		</ol>
+	</div>
+
+</div>
+
+<div class="demo-container">
+
+	<div class="o-stepped-progress o-stepped-progress--heavy" data-o-component="o-stepped-progress">
+		<ol class="o-stepped-progress__steps">
+			<li>
+				<a href="https://www.ft.com/" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label" aria-label="Completed: Example">Example</span>
+				</a>
+			</li>
+			<li>
+				<a href="https://www.ft.com/" class="o-stepped-progress__step o-stepped-progress__step--error">
+					<span class="o-stepped-progress__label" aria-label="Error: Example">Example</span>
+				</a>
+			</li>
+			<li>
+				<a href="./pa11y.html" class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label" aria-label="Current step: Example">Example</span>
+				</a>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Example</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Example</span>
+				</span>
+			</li>
+		</ol>
+	</div>
+
 </div>

--- a/demos/src/testing.mustache
+++ b/demos/src/testing.mustache
@@ -260,3 +260,66 @@
 	</div>
 
 </div>
+
+<div class="demo-container">
+
+	<div class="o-stepped-progress o-stepped-progress--heavy" data-o-component="o-stepped-progress">
+		<ol class="o-stepped-progress__steps">
+			<li>
+				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 1</span>
+				</a>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label">Step 2</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Step 3</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Step 4</span>
+				</span>
+			</li>
+		</ol>
+	</div>
+
+</div>
+
+<div class="demo-container">
+
+	<div class="o-stepped-progress o-stepped-progress--heavy" data-o-component="o-stepped-progress">
+		<ol class="o-stepped-progress__steps">
+			<li>
+				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 1</span>
+				</a>
+			</li>
+			<li>
+				<a href="#step-2" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 2</span>
+				</a>
+			</li>
+			<li>
+				<a href="#step-3" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 3</span>
+				</a>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step o-stepped-progress__step--error">
+					<span class="o-stepped-progress__label">Step 4</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Step 5</span>
+				</span>
+			</li>
+		</ol>
+	</div>
+
+</div>

--- a/demos/src/testing.mustache
+++ b/demos/src/testing.mustache
@@ -1,0 +1,262 @@
+
+<div class="demo-container">
+
+	<div class="o-stepped-progress" data-o-component="o-stepped-progress">
+		<ol class="o-stepped-progress__steps">
+			<li>
+				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 1</span>
+				</a>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label">Step 2</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Step 3</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Step 4</span>
+				</span>
+			</li>
+		</ol>
+	</div>
+
+</div>
+
+<div class="demo-container">
+
+	<div class="o-stepped-progress" data-o-component="o-stepped-progress">
+		<ol class="o-stepped-progress__steps">
+			<li>
+				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Details</span>
+				</a>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label">Delivery</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Customise</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Payment</span>
+				</span>
+			</li>
+		</ol>
+	</div>
+
+</div>
+
+<div class="demo-container">
+
+	<div class="o-stepped-progress" data-o-component="o-stepped-progress">
+		<ol class="o-stepped-progress__steps">
+			<li>
+				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 1</span>
+				</a>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label">Step 2</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">This is a longer label than we might be expecting</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Step 4</span>
+				</span>
+			</li>
+		</ol>
+	</div>
+
+</div>
+
+<div class="demo-container">
+
+	<div class="o-stepped-progress" data-o-component="o-stepped-progress">
+		<ol class="o-stepped-progress__steps">
+			<li>
+				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 1</span>
+				</a>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label">Step 2</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Step 3</span>
+				</span>
+			</li>
+		</ol>
+	</div>
+
+</div>
+
+<div class="demo-container">
+
+	<div class="o-stepped-progress" data-o-component="o-stepped-progress">
+		<ol class="o-stepped-progress__steps">
+			<li>
+				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 1</span>
+				</a>
+			</li>
+			<li>
+				<a href="#step-2" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 2</span>
+				</a>
+			</li>
+			<li>
+				<a href="#step-3" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 3</span>
+				</a>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label">Step 4</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Step 5</span>
+				</span>
+			</li>
+		</ol>
+	</div>
+
+</div>
+
+<div class="demo-container">
+
+	<div class="o-stepped-progress" data-o-component="o-stepped-progress">
+		<ol class="o-stepped-progress__steps">
+			<li>
+				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 1</span>
+				</a>
+			</li>
+			<li>
+				<a href="#step-2" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 2</span>
+				</a>
+			</li>
+			<li>
+				<a href="#step-3" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 3</span>
+				</a>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step o-stepped-progress__step--error">
+					<span class="o-stepped-progress__label">Step 4</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Step 5</span>
+				</span>
+			</li>
+		</ol>
+	</div>
+
+</div>
+
+<div class="demo-container">
+
+	<div class="o-stepped-progress" data-o-component="o-stepped-progress">
+		<ol class="o-stepped-progress__steps">
+			<li>
+				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 1</span>
+				</a>
+			</li>
+			<li>
+				<a href="#step-2" class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label">Step 2</span>
+				</a>
+			</li>
+			<li>
+				<a href="#step-3" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 3</span>
+				</a>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 4</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Step 5</span>
+				</span>
+			</li>
+		</ol>
+	</div>
+
+</div>
+
+<div class="demo-container">
+
+	<div class="o-stepped-progress" data-o-component="o-stepped-progress">
+		<ol class="o-stepped-progress__steps">
+			<li>
+				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 1</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 2</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">Step 3</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label">Step 4</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Step 5</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Step 6</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Step 7</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Step 8</span>
+				</span>
+			</li>
+		</ol>
+	</div>
+
+</div>

--- a/demos/src/testing.mustache
+++ b/demos/src/testing.mustache
@@ -5,22 +5,22 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Apple">Apple</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
 				</a>
 			</li>
 			<li>
-				<a href="#" class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label" aria-label="Current step: Banana">Banana</span>
-				</a>
-			</li>
-			<li>
-				<span class="o-stepped-progress__step">
-					<span class="o-stepped-progress__label">Orange</span>
+				<span class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label" aria-label="Current step: Step 2">Step 2</span>
 				</span>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step">
-					<span class="o-stepped-progress__label">Pear</span>
+					<span class="o-stepped-progress__label">Step 3</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Step 4</span>
 				</span>
 			</li>
 		</ol>
@@ -33,13 +33,13 @@
 	<div class="o-stepped-progress" data-o-component="o-stepped-progress">
 		<ol class="o-stepped-progress__steps">
 			<li>
-				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
-				</a>
+				<span href="#step-1" class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Step 1</span>
+				</span>
 			</li>
 			<li>
-				<span class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label" aria-label="Current step: Step 2">Step 2</span>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Step 2</span>
 				</span>
 			</li>
 			<li>
@@ -79,35 +79,6 @@
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
 					<span class="o-stepped-progress__label" aria-label="Completed: Step 4">Step 4</span>
-				</span>
-			</li>
-		</ol>
-	</div>
-
-</div>
-
-<div class="demo-container">
-
-	<div class="o-stepped-progress" data-o-component="o-stepped-progress">
-		<ol class="o-stepped-progress__steps">
-			<li>
-				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Details">Details</span>
-				</a>
-			</li>
-			<li>
-				<span class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label" aria-label="Current step: Delivery">Delivery</span>
-				</span>
-			</li>
-			<li>
-				<span class="o-stepped-progress__step">
-					<span class="o-stepped-progress__label">Customise</span>
-				</span>
-			</li>
-			<li>
-				<span class="o-stepped-progress__step">
-					<span class="o-stepped-progress__label">Payment</span>
 				</span>
 			</li>
 		</ol>

--- a/demos/src/testing.mustache
+++ b/demos/src/testing.mustache
@@ -5,12 +5,41 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 1</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Apple">Apple</span>
+				</a>
+			</li>
+			<li>
+				<a href="#" class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label" aria-label="Current step: Banana">Banana</span>
+				</a>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Orange</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step">
+					<span class="o-stepped-progress__label">Pear</span>
+				</span>
+			</li>
+		</ol>
+	</div>
+
+</div>
+
+<div class="demo-container">
+
+	<div class="o-stepped-progress" data-o-component="o-stepped-progress">
+		<ol class="o-stepped-progress__steps">
+			<li>
+				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
 				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label">Step 2</span>
+					<span class="o-stepped-progress__label" aria-label="Current step: Step 2">Step 2</span>
 				</span>
 			</li>
 			<li>
@@ -34,12 +63,41 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Details</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
+				</a>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 2">Step 2</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 3">Step 3</span>
+				</span>
+			</li>
+			<li>
+				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 4">Step 4</span>
+				</span>
+			</li>
+		</ol>
+	</div>
+
+</div>
+
+<div class="demo-container">
+
+	<div class="o-stepped-progress" data-o-component="o-stepped-progress">
+		<ol class="o-stepped-progress__steps">
+			<li>
+				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label" aria-label="Completed: Details">Details</span>
 				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label">Delivery</span>
+					<span class="o-stepped-progress__label" aria-label="Current step: Delivery">Delivery</span>
 				</span>
 			</li>
 			<li>
@@ -63,12 +121,12 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 1</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
 				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label">Step 2</span>
+					<span class="o-stepped-progress__label" aria-label="Current step: Step 2">Step 2</span>
 				</span>
 			</li>
 			<li>
@@ -92,12 +150,12 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 1</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
 				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label">Step 2</span>
+					<span class="o-stepped-progress__label" aria-label="Current step: Step 2">Step 2</span>
 				</span>
 			</li>
 			<li>
@@ -116,22 +174,22 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 1</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
 				</a>
 			</li>
 			<li>
 				<a href="#step-2" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 2</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 2">Step 2</span>
 				</a>
 			</li>
 			<li>
 				<a href="#step-3" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 3</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 3">Step 3</span>
 				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label">Step 4</span>
+					<span class="o-stepped-progress__label" aria-label="Current step: Step 4">Step 4</span>
 				</span>
 			</li>
 			<li>
@@ -150,17 +208,17 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 1</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
 				</a>
 			</li>
 			<li>
 				<a href="#step-2" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 2</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 2">Step 2</span>
 				</a>
 			</li>
 			<li>
 				<a href="#step-3" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 3</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 3">Step 3</span>
 				</a>
 			</li>
 			<li>
@@ -184,22 +242,22 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 1</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
 				</a>
 			</li>
 			<li>
 				<a href="#step-2" class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label">Step 2</span>
+					<span class="o-stepped-progress__label" aria-label="Current step: Step 2">Step 2</span>
 				</a>
 			</li>
 			<li>
 				<a href="#step-3" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 3</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 3">Step 3</span>
 				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 4</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 4">Step 4</span>
 				</span>
 			</li>
 			<li>
@@ -218,22 +276,22 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 1</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
 				</span>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 2</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 2">Step 2</span>
 				</span>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 3</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 3">Step 3</span>
 				</span>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label">Step 4</span>
+					<span class="o-stepped-progress__label" aria-label="Current step: Step 4">Step 4</span>
 				</span>
 			</li>
 			<li>
@@ -267,12 +325,12 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 1</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
 				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label">Step 2</span>
+					<span class="o-stepped-progress__label" aria-label="Current step: Step 2">Step 2</span>
 				</span>
 			</li>
 			<li>
@@ -296,17 +354,17 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 1</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
 				</a>
 			</li>
 			<li>
 				<a href="#step-2" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 2</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 2">Step 2</span>
 				</a>
 			</li>
 			<li>
 				<a href="#step-3" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label">Step 3</span>
+					<span class="o-stepped-progress__label" aria-label="Completed: Step 3">Step 3</span>
 				</a>
 			</li>
 			<li>

--- a/main.scss
+++ b/main.scss
@@ -1,4 +1,9 @@
 
+@import 'o-colors/main';
+@import 'o-icons/main';
+@import 'o-typography/main';
+
+@import 'src/scss/brand';
 @import 'src/scss/variables';
 @import 'src/scss/functions';
 @import 'src/scss/mixins';

--- a/origami.json
+++ b/origami.json
@@ -29,6 +29,12 @@
 	},
 	"demos": [
 		{
+			"title": "Testing",
+			"name": "testing",
+			"template": "demos/src/testing.mustache",
+			"description": "Testing styles"
+		},
+		{
 			"title": "Pa11y",
 			"name": "pa11y",
 			"template": "demos/src/pa11y.mustache",

--- a/origami.json
+++ b/origami.json
@@ -24,6 +24,7 @@
 		"js": "demos/src/demo.js",
 		"dependencies": [
 			"o-fonts@^3.0.0",
+			"o-icons@^5.8.0",
 			"o-normalise@^1.0.0"
 		]
 	},

--- a/origami.json
+++ b/origami.json
@@ -29,16 +29,48 @@
 	},
 	"demos": [
 		{
-			"title": "Testing",
-			"name": "testing",
-			"template": "demos/src/testing.mustache",
-			"description": "Testing styles"
+			"name": "stepped-progress",
+			"title": "Stepped Progress",
+			"description": "A basic stepped progress indicator, with completed and current steps. This demonstrates using stepped progress for a signup form.",
+			"template": "demos/src/demo.mustache",
+			"data": "demos/src/data/signup-form.json"
 		},
 		{
-			"title": "Pa11y",
+			"name": "error-step",
+			"title": "Error Step",
+			"description": "A stepped progress indicator with an errored step.",
+			"template": "demos/src/demo.mustache",
+			"data": "demos/src/data/signup-form-error.json"
+		},
+		{
+			"name": "html-labels",
+			"title": "HTML Labels",
+			"description": "A stepped progress indicator with richer labels, using other components.",
+			"template": "demos/src/demo.mustache",
+			"data": "demos/src/data/html-labels.json"
+		},
+		{
+			"name": "heavy",
+			"title": "Heavy Variant",
+			"description": "A stepped progress with the “heavy” variant.",
+			"template": "demos/src/demo.mustache",
+			"data": "demos/src/data/renewal-timeline.json",
+			"brands": [
+				"internal"
+			]
+		},
+		{
+			"name": "testing",
+			"title": "Testing All Styles",
+			"description": "A hidden demo for manual cross-browser testing. This includes all of the possible styles and lots of variations on numbers of steps etc.",
+			"template": "demos/src/testing.mustache",
+			"hidden": true
+		},
+		{
 			"name": "pa11y",
-			"template": "demos/src/pa11y.mustache",
+			"title": "Pa11y",
 			"description": "Accessibility tests will be run against this demo",
+			"template": "demos/src/pa11y.mustache",
 			"hidden": true
 		}
 	]

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -16,7 +16,7 @@ $_o-stepped-progress-shared-brand-config: (
 	font-scale: -1,
 	step-size: 22px,
 	step-border-size: 2px,
-	label-max-width: 140px,
+	label-max-width: 10em,
 	bar-weight: 2px,
 	container-background: oColorsGetPaletteColor(oColorsGetUseCase('page', 'background')),
 	default-color: oColorsGetPaletteColor('black-40'),

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -35,8 +35,17 @@ $_o-stepped-progress-shared-brand-config: (
 // Define internal brand
 @if oBrandGetCurrentBrand() == 'internal' {
 	@include oBrandDefine('o-stepped-progress', 'internal', (
-		'variables': map-merge($_o-stepped-progress-shared-brand-config, ()),
-		'supports-variants': ()
+		'variables': map-merge($_o-stepped-progress-shared-brand-config, (
+			'heavy': (
+				font-scale: 0,
+				step-size: 26px,
+				step-border-size: 5px,
+				bar-weight: 6px
+			)
+		)),
+		'supports-variants': (
+			'heavy'
+		)
 	));
 }
 

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -1,0 +1,49 @@
+
+/// Helper for `o-brand` function.
+/// @access private
+@function _oSteppedProgressGet($variables, $from: null) {
+	@return oBrandGet($component: 'o-stepped-progress', $variables: $variables, $from: $from);
+}
+
+/// Helper for `o-brand` function.
+/// @access private
+@function _oSteppedProgressSupports($variant) {
+	@return oBrandSupportsVariant($component: 'o-stepped-progress', $variant: $variant);
+}
+
+// Define shared brand configurations
+$_o-stepped-progress-shared-brand-config: (
+	font-scale: -1,
+	step-size: 22px,
+	step-border-size: 2px,
+	label-max-width: 140px,
+	bar-weight: 2px,
+	container-background: oColorsGetPaletteColor(oColorsGetUseCase('page', 'background')),
+	default-color: oColorsGetPaletteColor('black-40'),
+	interacted-color: oColorsGetPaletteColor('slate'),
+	error-color: oColorsMix('crimson', oColorsGetUseCase('page', 'background'), 90)
+);
+
+// Define masterbrand
+@if oBrandGetCurrentBrand() == 'master' {
+	@include oBrandDefine('o-stepped-progress', 'master', (
+		'variables': map-merge($_o-stepped-progress-shared-brand-config, ()),
+		'supports-variants': ()
+	));
+}
+
+// Define internal brand
+@if oBrandGetCurrentBrand() == 'internal' {
+	@include oBrandDefine('o-stepped-progress', 'internal', (
+		'variables': map-merge($_o-stepped-progress-shared-brand-config, ()),
+		'supports-variants': ()
+	));
+}
+
+// Define whitelabel brand
+@if oBrandGetCurrentBrand() == 'whitelabel' {
+	@include oBrandDefine('o-stepped-progress', 'whitelabel', (
+		'variables': map-merge($_o-stepped-progress-shared-brand-config, ()),
+		'supports-variants': ()
+	));
+}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,11 +1,30 @@
 
 /// Outputs all available features and styles for stepped progress.
 ///
+/// @output The output includes the `.o-stepped-progress` class definition as well as class definitions for every available theme.
+/// @example scss - All stepped progress styles
+///   @include oSteppedProgress();
+/// @example scss - Base styles with 'heavy' theme
+///   @include oLabels((
+///     'themes': (
+///       'heavy'
+///     )
+///   ));
 /// @access public
-@mixin oSteppedProgress() {
+@mixin oSteppedProgress($opts: (
+	'themes': (
+		'heavy'
+	)
+)) {
+	$themes: map_get($opts, 'themes');
 
 	// Base stepped progress styles
 	@include _oSteppedProgressBase();
+
+	// Heavy theme
+	@if index($themes, 'heavy') and _oSteppedProgressSupports('heavy') {
+		@include _oSteppedProgressHeavy();
+	}
 
 }
 
@@ -174,10 +193,68 @@
 
 }
 
-/// Output a stepped progress specific error message
+/// Heavy theme for the stepped progress component.
 ///
-/// @param {String} $message - The message to insert in the error.
+/// @output The output includes the `.o-stepped-progress--heavy` class definition and all style overrides for it.
+/// @example scss - Heavy stepped progress styles
+///   @include _oSteppedProgressHeavy();
 /// @access private
-@mixin _oSteppedProgressError($message) {
-	@error '*** oSteppedProgress SCSS error: #{$message} ***';
-};
+@mixin _oSteppedProgressHeavy() {
+	$variant: 'heavy';
+
+	.o-stepped-progress--heavy {
+
+		@include oTypographySans(_oSteppedProgressGet('font-scale', $variant));
+
+		// Progress bars
+		&:before {
+			height: _oSteppedProgressGet('bar-weight', $variant);
+			top: (_oSteppedProgressGet('step-size', $variant) / 2) - (_oSteppedProgressGet('bar-weight', $variant) / 2);
+		}
+		.o-stepped-progress__step--complete,
+		.o-stepped-progress__step--current,
+		.o-stepped-progress__step--error {
+			&:after {
+				height: _oSteppedProgressGet('bar-weight', $variant);
+				top: (_oSteppedProgressGet('step-size', $variant) / 2) - (_oSteppedProgressGet('bar-weight', $variant) / 2);
+			}
+		}
+
+		// The step type indicator
+		.o-stepped-progress__step {
+			&:before {
+				height: _oSteppedProgressGet('step-size', $variant) - (_oSteppedProgressGet('step-border-size', $variant) * 2);
+				width: _oSteppedProgressGet('step-size', $variant) - (_oSteppedProgressGet('step-border-size', $variant) * 2);
+				border-width: _oSteppedProgressGet('step-border-size', $variant);
+			}
+		}
+
+		// Completed step modifier
+		.o-stepped-progress__step--complete {
+			&:before {
+				background-color: _oSteppedProgressGet('container-background');
+				background-size: 160%;
+				background-position: 35% 35%;
+				background-origin: content-box;
+				border-color: _oSteppedProgressGet('interacted-color');
+
+				@include oIconsGetIcon(
+					$icon-name: 'tick',
+					$color: _oSteppedProgressGet('interacted-color'),
+					$apply-base-styles: false,
+					$apply-width-height: false
+				);
+			}
+		}
+
+		// Current step modifier
+		.o-stepped-progress__step--current {
+			&:before {
+				background-color: _oSteppedProgressGet('container-background');
+				box-shadow: none;
+			}
+		}
+
+	}
+
+}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -3,9 +3,175 @@
 ///
 /// @access public
 @mixin oSteppedProgress() {
+
+	// Base stepped progress styles
+	@include _oSteppedProgressBase();
+
+}
+
+/// Base styles for stepped progress.
+///
+/// @output The output includes the `.o-stepped-progress` class definition and all styles for a basic stepped progress.
+/// @example scss - Base stepped progress styles
+///   @include _oSteppedProgressBase();
+/// @access private
+@mixin _oSteppedProgressBase() {
+
 	.o-stepped-progress {
 		display: block;
+		position: relative;
+		@include oTypographySans(_oSteppedProgressGet('font-scale'));
+
+		a {
+			color: inherit;
+			text-decoration: underline;
+		}
 	}
+
+	// Progress bar
+	.o-stepped-progress:before {
+		content: '';
+		display: block;
+		width: 100%;
+		height: _oSteppedProgressGet('bar-weight');
+		position: absolute;
+		top: (_oSteppedProgressGet('step-size') / 2) - (_oSteppedProgressGet('bar-weight') / 2);
+		background-color: _oSteppedProgressGet('default-color');
+	}
+
+	.o-stepped-progress__steps {
+		list-style: none;
+		padding-left: 0;
+		margin-top: 0;
+		margin-bottom: 0;
+		display: flex;
+		justify-content: space-between;
+		position: relative;
+		z-index: 10;
+		overflow: hidden;
+
+		> li {
+			display: flex;
+			flex-basis: 0;
+			flex-grow: 2;
+			justify-content: center;
+			width: auto;
+
+			&:first-child {
+				flex-grow: 1;
+				justify-content: flex-start;
+			}
+
+			&:last-child {
+				flex-grow: 1;
+				justify-content: flex-end;
+			}
+		}
+	}
+
+	// Individual step
+	.o-stepped-progress__step {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+
+		// Sensible line length but also fixes a flex bug in IE 11
+		max-width: _oSteppedProgressGet('label-max-width');
+
+		// The first and last step must be aligned differently:
+		// the first is aligned left and the last is aligned right
+		.o-stepped-progress__steps > li:first-child & {
+			align-items: flex-start;
+			text-align: left;
+		}
+		.o-stepped-progress__steps > li:last-child & {
+			align-items: flex-end;
+			text-align: right;
+		}
+
+		// The step type indicator
+		&:before {
+			content: '';
+			display: inline-block;
+			height: _oSteppedProgressGet('step-size') - (_oSteppedProgressGet('step-border-size') * 2);
+			width: _oSteppedProgressGet('step-size') - (_oSteppedProgressGet('step-border-size') * 2);
+			margin-bottom: oTypographySpacingSize(1);
+			background-color: _oSteppedProgressGet('container-background');
+			background-repeat: no-repeat;
+			background-origin: border-box;
+			background-position: center;
+			background-size: 100%;
+			border-radius: 50%;
+			border: solid _oSteppedProgressGet('step-border-size') _oSteppedProgressGet('default-color');
+		}
+	}
+
+	// The complete and current steps render the black progress bar
+	// after themselves. Both step modifiers need these styles
+	.o-stepped-progress__step--complete,
+	.o-stepped-progress__step--current,
+	.o-stepped-progress__step--error {
+		position: relative;
+
+		&:after {
+			content: '';
+			display: block;
+			width: 100vw;
+			height: _oSteppedProgressGet('bar-weight');
+			position: absolute;
+			top: (_oSteppedProgressGet('step-size') / 2) - (_oSteppedProgressGet('bar-weight') / 2);
+			right: 50%;
+			z-index: -5;
+			background-color: _oSteppedProgressGet('interacted-color');
+		}
+	}
+
+	// Completed step modifier
+	.o-stepped-progress__step--complete {
+		&:before {
+			background-color: _oSteppedProgressGet('interacted-color');
+			border-color: transparent;
+			@include oIconsGetIcon(
+				$icon-name: 'tick',
+				$color: _oSteppedProgressGet('container-background'),
+				$apply-base-styles: false,
+				$apply-width-height: false
+			);
+		}
+	}
+
+	// Current step modifier
+	.o-stepped-progress__step--current {
+		&:before {
+			background-color: _oSteppedProgressGet('interacted-color');
+			border-color: _oSteppedProgressGet('interacted-color');
+			box-shadow: inset 0px 0px 0px _oSteppedProgressGet('step-border-size') _oSteppedProgressGet('container-background');
+		}
+	}
+
+	// Errored step modifier
+	.o-stepped-progress__step--error {
+		&:before {
+			background-color: _oSteppedProgressGet('error-color');
+			border-color: transparent;
+			@include oIconsGetIcon(
+				$icon-name: 'warning',
+				$color: _oSteppedProgressGet('container-background'),
+				$apply-base-styles: false,
+				$apply-width-height: false
+			);
+		}
+	}
+
+	// Step label styles
+	.o-stepped-progress__label {
+		// Sensible line length but also fixes a flex bug in IE 11.
+		// Repetition of this line from .o-stepped-progress__stepped
+		// is required for the fix to work.
+		max-width: _oSteppedProgressGet('label-max-width');
+	}
+
 }
 
 /// Output a stepped progress specific error message

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -37,9 +37,9 @@
 @mixin _oSteppedProgressBase() {
 
 	.o-stepped-progress {
+		@include oTypographySans(_oSteppedProgressGet('font-scale'));
 		display: block;
 		position: relative;
-		@include oTypographySans(_oSteppedProgressGet('font-scale'));
 
 		a {
 			color: inherit;
@@ -149,14 +149,14 @@
 	// Completed step modifier
 	.o-stepped-progress__step--complete {
 		&:before {
-			background-color: _oSteppedProgressGet('interacted-color');
-			border-color: transparent;
 			@include oIconsGetIcon(
 				$icon-name: 'tick',
 				$color: _oSteppedProgressGet('container-background'),
 				$apply-base-styles: false,
 				$apply-width-height: false
 			);
+			background-color: _oSteppedProgressGet('interacted-color');
+			border-color: transparent;
 		}
 	}
 
@@ -172,14 +172,14 @@
 	// Errored step modifier
 	.o-stepped-progress__step--error {
 		&:before {
-			background-color: _oSteppedProgressGet('error-color');
-			border-color: transparent;
 			@include oIconsGetIcon(
 				$icon-name: 'warning',
 				$color: _oSteppedProgressGet('container-background'),
 				$apply-base-styles: false,
 				$apply-width-height: false
 			);
+			background-color: _oSteppedProgressGet('error-color');
+			border-color: transparent;
 		}
 	}
 
@@ -203,7 +203,6 @@
 	$variant: 'heavy';
 
 	.o-stepped-progress--heavy {
-
 		@include oTypographySans(_oSteppedProgressGet('font-scale', $variant));
 
 		// Progress bars
@@ -232,18 +231,17 @@
 		// Completed step modifier
 		.o-stepped-progress__step--complete {
 			&:before {
-				background-color: _oSteppedProgressGet('container-background');
-				background-size: 160%;
-				background-position: 35% 35%;
-				background-origin: content-box;
-				border-color: _oSteppedProgressGet('interacted-color');
-
 				@include oIconsGetIcon(
 					$icon-name: 'tick',
 					$color: _oSteppedProgressGet('interacted-color'),
 					$apply-base-styles: false,
 					$apply-width-height: false
 				);
+				background-color: _oSteppedProgressGet('container-background');
+				background-size: 160%;
+				background-position: 35% 35%;
+				background-origin: content-box;
+				border-color: _oSteppedProgressGet('interacted-color');
 			}
 		}
 

--- a/test/scss/index.test.scss
+++ b/test/scss/index.test.scss
@@ -4,4 +4,5 @@
 
 $_test-environment: true;
 
-@import 'mixins.test';
+// TODO add tests and uncommend this line
+// @import 'mixins.test';


### PR DESCRIPTION
This adds in the styles for basic and heavy stepped progress indicators. I think this is enough for us to release a beta. This doesn't contain documentation and Sass tests, I'd like to PR those separately as this is already quite a large PR.

Also IE9 isn't tested and (based on Lee's feedback) is broken. I'd like to PR this work separately as well.

## Master styles

<img width="627" alt="Master styles" src="https://user-images.githubusercontent.com/138944/49729868-9e76fb80-fc6e-11e8-80b8-337b877f4134.png">

## Internal Styles

<img width="630" alt="Internal styles" src="https://user-images.githubusercontent.com/138944/49729899-ac2c8100-fc6e-11e8-96dd-a80e6d70777d.png">
