### PR TITLE
Remove high contrast mode from icons

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -178,7 +178,8 @@
 				$icon-name: 'tick',
 				$color: _oSteppedProgressGet('container-background'),
 				$apply-base-styles: false,
-				$apply-width-height: false
+				$apply-width-height: false,
+				$high-contrast-fallback: false
 			);
 			background-color: _oSteppedProgressGet('interacted-color');
 			border-color: transparent;
@@ -201,7 +202,8 @@
 				$icon-name: 'warning',
 				$color: _oSteppedProgressGet('container-background'),
 				$apply-base-styles: false,
-				$apply-width-height: false
+				$apply-width-height: false,
+				$high-contrast-fallback: false
 			);
 			background-color: _oSteppedProgressGet('error-color');
 			border-color: transparent;
@@ -260,7 +262,8 @@
 					$icon-name: 'tick',
 					$color: _oSteppedProgressGet('interacted-color'),
 					$apply-base-styles: false,
-					$apply-width-height: false
+					$apply-width-height: false,
+					$high-contrast-fallback: false
 				);
 				background-color: _oSteppedProgressGet('container-background');
 				background-size: 160%;


### PR DESCRIPTION
I think this maybe warrants some more investigation and some work on
o-icons itself. I couldn't find a difference in the way icons are
displayed in any of the high contrast modes in Windows 10 + Edge,
regardless of whether we provide specific styles for them.

The only time the experience was degraded in high contrast mode was when
a white background is selected, which isn't catered for by the o-icons
code - we should probably add this.

For now I'm just going to remove them from stepped progress as the
required media queries add a fair amount of CSS when bundled. I'll open
an issue on o-icons to investigate further and update this once we have
support for black-on-white high contrast.