### PR TITLE
Fix the progress bar alignment for first/last step

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -115,10 +115,20 @@
 		.o-stepped-progress__steps > li:first-child & {
 			align-items: flex-start;
 			text-align: left;
+
+			// Progress bar alignment
+			&::after {
+				right: 100%;
+			}
 		}
 		.o-stepped-progress__steps > li:last-child & {
 			align-items: flex-end;
 			text-align: right;
+
+			// Progress bar alignment
+			&::after {
+				right: 0;
+			}
 		}
 
 		// The step type indicator


### PR DESCRIPTION
The progress bar was misaligned if the first or last step had longer
text, I hadn't spotted before because we only ever had short text in the
demos for the first and last steps.