### PR TITLE
Move accessible text to a hidden element

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
 	"dependencies": {
 		"o-colors": "^4.7.7",
 		"o-icons": "^5.8.0",
+		"o-normalise": "^1.6.2",
 		"o-typography": "^5.7.8"
 	}
 }

--- a/demos/src/data/html-labels.json
+++ b/demos/src/data/html-labels.json
@@ -2,18 +2,15 @@
 	"steps": [
 		{
 			"label": "Step with icon <i class=\"o-icons-icon o-icons-icon--edit\" style=\"width: 20px; height: 20px; vertical-align: middle;\"><!-- Inline styles here should be in CSS or SCSS files when implementing --></i>",
-			"accessibleLabel": "Step with icon",
 			"url": "#edit",
 			"isComplete": true
 		},
 		{
 			"label": "Step with<br/>multiple</br>line breaks",
-			"accessibleLabel": "Step with multiple line breaks",
 			"isCurrent": true
 		},
 		{
-			"label": "Step with <strong>bold</strong> and <em>italic</em> text",
-			"accessibleLabel": "Step with bold and italic text"
+			"label": "Step with <strong>bold</strong> and <em>italic</em> text"
 		}
 	]
 }

--- a/demos/src/data/renewal-timeline.json
+++ b/demos/src/data/renewal-timeline.json
@@ -3,22 +3,18 @@
 	"steps": [
 		{
 			"label": "<strong>Contract start date</strong><br/> 22 Jan 2018",
-			"accessibleLabel": "Contract start date, 22 Jan 2018",
 			"isComplete": true
 		},
 		{
 			"label": "<strong>Planning meeting</strong><br/> 22 Feb 2018",
-			"accessibleLabel": "Planning meeting, 22 Feb 2018",
 			"isComplete": true
 		},
 		{
 			"label": "<strong>Mid-year review</strong><br/> 22 June 2018",
-			"accessibleLabel": "Mid-year review, 22 June 2018",
 			"isCurrent": true
 		},
 		{
-			"label": "<strong>Renewal</strong><br/> 22 Nov 2018",
-			"accessibleLabel": "Renewal, 22 Nov 2018"
+			"label": "<strong>Renewal</strong><br/> 22 Nov 2018"
 		}
 	]
 }

--- a/demos/src/data/signup-form-error.json
+++ b/demos/src/data/signup-form-error.json
@@ -2,25 +2,21 @@
 	"steps": [
 		{
 			"label": "Details",
-			"accessibleLabel": "Details",
 			"url": "#details",
 			"isComplete": true
 		},
 		{
 			"label": "Delivery",
-			"accessibleLabel": "Delivery",
 			"url": "#delivery",
 			"isComplete": true
 		},
 		{
 			"label": "Customise",
-			"accessibleLabel": "Customise",
 			"url": "#customise",
 			"isError": true
 		},
 		{
-			"label": "Payment",
-			"accessibleLabel": "Payment"
+			"label": "Payment"
 		}
 	]
 }

--- a/demos/src/data/signup-form.json
+++ b/demos/src/data/signup-form.json
@@ -2,25 +2,21 @@
 	"steps": [
 		{
 			"label": "Details",
-			"accessibleLabel": "Details",
 			"url": "#details",
 			"isComplete": true
 		},
 		{
 			"label": "Delivery",
-			"accessibleLabel": "Delivery",
 			"url": "#delivery",
 			"isComplete": true
 		},
 		{
 			"label": "Customise",
-			"accessibleLabel": "Customise",
 			"url": "#customise",
 			"isCurrent": true
 		},
 		{
-			"label": "Payment",
-			"accessibleLabel": "Payment"
+			"label": "Payment"
 		}
 	]
 }

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -5,12 +5,16 @@
 		<li>
 			{{#url}}
 			<a href="{{url}}" class="o-stepped-progress__step{{#isComplete}} o-stepped-progress__step--complete{{/isComplete}}{{#isCurrent}} o-stepped-progress__step--current{{/isCurrent}}{{#isError}} o-stepped-progress__step--error{{/isError}}">
-				<span class="o-stepped-progress__label"{{#isComplete}} aria-label="Completed: {{accessibleLabel}}"{{/isComplete}}{{#isCurrent}} aria-label="Current step: {{accessibleLabel}}"{{/isCurrent}}{{#isError}} aria-label="Error: {{accessibleLabel}}"{{/isError}}>{{{label}}}</span>
+				<span class="o-stepped-progress__label">
+					{{{label}}}{{#isComplete}} <span class="o-stepped-progress__status">(completed)</span>{{/isComplete}}{{#isCurrent}} <span class="o-stepped-progress__status">(current step)</span>{{/isCurrent}}{{#isError}} <span class="o-stepped-progress__status">(error)</span>{{/isError}}
+				</span>
 			</a>
 			{{/url}}
 			{{^url}}
 			<span class="o-stepped-progress__step{{#isComplete}} o-stepped-progress__step--complete{{/isComplete}}{{#isCurrent}} o-stepped-progress__step--current{{/isCurrent}}{{#isError}} o-stepped-progress__step--error{{/isError}}">
-				<span class="o-stepped-progress__label"{{#isComplete}} aria-label="Completed: {{accessibleLabel}}"{{/isComplete}}{{#isCurrent}} aria-label="Current step: {{accessibleLabel}}"{{/isCurrent}}{{#isError}} aria-label="Error: {{accessibleLabel}}"{{/isError}}>{{{label}}}</span>
+				<span class="o-stepped-progress__label">
+					{{{label}}}{{#isComplete}} <span class="o-stepped-progress__status">(completed)</span>{{/isComplete}}{{#isCurrent}} <span class="o-stepped-progress__status">(current step)</span>{{/isCurrent}}{{#isError}} <span class="o-stepped-progress__status">(error)</span>{{/isError}}
+				</span>
 			</span>
 			{{/url}}
 		</li>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -5,27 +5,37 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="https://www.ft.com/" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Example">Example</span>
+					<span class="o-stepped-progress__label">
+						Example <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
 				<a href="https://www.ft.com/" class="o-stepped-progress__step o-stepped-progress__step--error">
-					<span class="o-stepped-progress__label" aria-label="Error: Example">Example</span>
+					<span class="o-stepped-progress__label">
+						Example <span class="o-stepped-progress__status">(error)</span>
+					</span>
 				</a>
 			</li>
 			<li>
 				<a href="./pa11y.html" class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label" aria-label="Current step: Example">Example</span>
+					<span class="o-stepped-progress__label">
+						Example <span class="o-stepped-progress__status">(current step)</span>
+					</span>
 				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step">
-					<span class="o-stepped-progress__label">Example</span>
+					<span class="o-stepped-progress__label">
+						Example
+					</span>
 				</span>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step">
-					<span class="o-stepped-progress__label">Example</span>
+					<span class="o-stepped-progress__label">
+						Example
+					</span>
 				</span>
 			</li>
 		</ol>
@@ -39,27 +49,37 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="https://www.ft.com/" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Example">Example</span>
+					<span class="o-stepped-progress__label">
+						Example <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
 				<a href="https://www.ft.com/" class="o-stepped-progress__step o-stepped-progress__step--error">
-					<span class="o-stepped-progress__label" aria-label="Error: Example">Example</span>
+					<span class="o-stepped-progress__label">
+						Example <span class="o-stepped-progress__status">(error)</span>
+					</span>
 				</a>
 			</li>
 			<li>
 				<a href="./pa11y.html" class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label" aria-label="Current step: Example">Example</span>
+					<span class="o-stepped-progress__label">
+						Example <span class="o-stepped-progress__status">(current step)</span>
+					</span>
 				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step">
-					<span class="o-stepped-progress__label">Example</span>
+					<span class="o-stepped-progress__label">
+						Example
+					</span>
 				</span>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step">
-					<span class="o-stepped-progress__label">Example</span>
+					<span class="o-stepped-progress__label">
+						Example
+					</span>
 				</span>
 			</li>
 		</ol>

--- a/demos/src/testing.mustache
+++ b/demos/src/testing.mustache
@@ -5,13 +5,17 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
+					<span class="o-stepped-progress__label">
+						Step 1 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
-				<span class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label" aria-label="Current step: Step 2">Step 2</span>
-				</span>
+				<a href="#step-2" class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label">
+						Step 2 <span class="o-stepped-progress__status">(current step)</span>
+					</span>
+				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step">
@@ -63,22 +67,30 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
+					<span class="o-stepped-progress__label">
+						Step 1 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 2">Step 2</span>
+					<span class="o-stepped-progress__label">
+						Step 2 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</span>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 3">Step 3</span>
+					<span class="o-stepped-progress__label">
+						Step 3 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</span>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 4">Step 4</span>
+					<span class="o-stepped-progress__label">
+						Step 4 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</span>
 			</li>
 		</ol>
@@ -92,13 +104,17 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
+					<span class="o-stepped-progress__label">
+						Step 1 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
-				<span class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label" aria-label="Current step: Step 2">Step 2</span>
-				</span>
+				<a href="#step-2" class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label">
+						Step 2 <span class="o-stepped-progress__status">(current step)</span>
+					</span>
+				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step">
@@ -121,13 +137,17 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
+					<span class="o-stepped-progress__label">
+						Step 1 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
-				<span class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label" aria-label="Current step: Step 2">Step 2</span>
-				</span>
+				<a href="#step-2" class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label">
+						Step 2 <span class="o-stepped-progress__status">(current step)</span>
+					</span>
+				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step">
@@ -145,23 +165,31 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
+					<span class="o-stepped-progress__label">
+						Step 1 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
 				<a href="#step-2" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 2">Step 2</span>
+					<span class="o-stepped-progress__label">
+						Step 2 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
 				<a href="#step-3" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 3">Step 3</span>
+					<span class="o-stepped-progress__label">
+						Step 3 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
-				<span class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label" aria-label="Current step: Step 4">Step 4</span>
-				</span>
+				<a href="#step-4" class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label">
+						Step 4 <span class="o-stepped-progress__status">(current step)</span>
+					</span>
+				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step">
@@ -179,23 +207,31 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
+					<span class="o-stepped-progress__label">
+						Step 1 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
 				<a href="#step-2" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 2">Step 2</span>
+					<span class="o-stepped-progress__label">
+						Step 2 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
 				<a href="#step-3" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 3">Step 3</span>
+					<span class="o-stepped-progress__label">
+						Step 3 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
-				<span class="o-stepped-progress__step o-stepped-progress__step--error">
-					<span class="o-stepped-progress__label">Step 4</span>
-				</span>
+				<a href="#step-4" class="o-stepped-progress__step o-stepped-progress__step--error">
+					<span class="o-stepped-progress__label">
+						Step 4 <span class="o-stepped-progress__status">(error)</span>
+					</span>
+				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step">
@@ -213,23 +249,31 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
+					<span class="o-stepped-progress__label">
+						Step 1 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
 				<a href="#step-2" class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label" aria-label="Current step: Step 2">Step 2</span>
+					<span class="o-stepped-progress__label">
+						Step 2 <span class="o-stepped-progress__status">(current step)</span>
+					</span>
 				</a>
 			</li>
 			<li>
 				<a href="#step-3" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 3">Step 3</span>
+					<span class="o-stepped-progress__label">
+						Step 3 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
-				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 4">Step 4</span>
-				</span>
+				<a href="#step-4" class="o-stepped-progress__step o-stepped-progress__step--complete">
+					<span class="o-stepped-progress__label">
+						Step 4 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
+				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step">
@@ -247,23 +291,31 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
+					<span class="o-stepped-progress__label">
+						Step 1 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</span>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 2">Step 2</span>
+					<span class="o-stepped-progress__label">
+						Step 2 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</span>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 3">Step 3</span>
+					<span class="o-stepped-progress__label">
+						Step 3 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</span>
 			</li>
 			<li>
-				<span class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label" aria-label="Current step: Step 4">Step 4</span>
-				</span>
+				<a href="#step-4" class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label">
+						Step 4 <span class="o-stepped-progress__status">(current step)</span>
+					</span>
+				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step">
@@ -296,13 +348,17 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
+					<span class="o-stepped-progress__label">
+						Step 1 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
-				<span class="o-stepped-progress__step o-stepped-progress__step--current">
-					<span class="o-stepped-progress__label" aria-label="Current step: Step 2">Step 2</span>
-				</span>
+				<a href="#step-2" class="o-stepped-progress__step o-stepped-progress__step--current">
+					<span class="o-stepped-progress__label">
+						Step 2 <span class="o-stepped-progress__status">(current step)</span>
+					</span>
+				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step">
@@ -325,23 +381,31 @@
 		<ol class="o-stepped-progress__steps">
 			<li>
 				<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 1">Step 1</span>
+					<span class="o-stepped-progress__label">
+						Step 1 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
 				<a href="#step-2" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 2">Step 2</span>
+					<span class="o-stepped-progress__label">
+						Step 2 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
 				<a href="#step-3" class="o-stepped-progress__step o-stepped-progress__step--complete">
-					<span class="o-stepped-progress__label" aria-label="Completed: Step 3">Step 3</span>
+					<span class="o-stepped-progress__label">
+						Step 3 <span class="o-stepped-progress__status">(completed)</span>
+					</span>
 				</a>
 			</li>
 			<li>
-				<span class="o-stepped-progress__step o-stepped-progress__step--error">
-					<span class="o-stepped-progress__label">Step 4</span>
-				</span>
+				<a href="#step-4" class="o-stepped-progress__step o-stepped-progress__step--error">
+					<span class="o-stepped-progress__label">
+						Step 4 <span class="o-stepped-progress__status">(error)</span>
+					</span>
+				</a>
 			</li>
 			<li>
 				<span class="o-stepped-progress__step">

--- a/main.scss
+++ b/main.scss
@@ -1,6 +1,7 @@
 
 @import 'o-colors/main';
 @import 'o-icons/main';
+@import 'o-normalise/main';
 @import 'o-typography/main';
 
 @import 'src/scss/brand';

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -228,6 +228,25 @@
 		max-width: _oSteppedProgressGet('label-max-width');
 	}
 
+	// Step status indicator (for core experience and screen readers)
+	@supports (display: flex) {
+		.o-stepped-progress__status {
+			@include oNormaliseVisuallyHidden();
+		}
+	}
+
+	// IE hack:
+	// The @supports directive is not supported by IE 10/11, but we
+	// do need to hide the progress status from them. We duplicate
+	// the styles for these browsers
+	// sass-lint:disable-all
+	@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+		.o-stepped-progress__status {
+			@include oNormaliseVisuallyHidden();
+		}
+	}
+	// sass-lint:enable-all
+
 }
 
 /// Heavy theme for the stepped progress component.


### PR DESCRIPTION
Using aria labels was fine for screen readers, but doesn't cater for a
core experience where the state icons may not be visible. The state text
has now moved to a hidden element so that the core experience (and
failed CSS experience) are more usable.

Before
------

  - **No CSS:** Displays as an ordered list without state icons and text
  - **IE < 9:** Displays as a stacked list without state icons and text
  - **IE 9:** Displays as a stacked list with icons but no text
  - **IE 10+:** Displays as a horizontal list with icons and no text
  - **Others:** Displays as a horizontal list with icons and no text

After
-----

  - **No CSS:** Displays as an ordered list with text but no icons
  - **IE < 9:** Displays as a stacked list with text but no icons
  - **IE 9:** Displays as a stacked list with text and icons
  - **IE 10+:** Displays as a horizontal list with icons and no text
  - **Others:** Displays as a horizontal list with icons and no text

The only compromise here is that IE 9 gets both text and icons, but the
code hoops I'd have to jump through to hide the text would be even more
gross than what I've had to do already.