### PR TITLE
Write SteppedProgress JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,44 @@ TODO
 
 ### JavaScript
 
-TODO
+No code will run automatically unless you are using the [Build Service](https://www.ft.com/__origami/service/build/). You must either construct an o-stepped-progress object or trigger an `o.DOMContentLoaded` event, which o-stepped-progress listens for.
+
+#### Constructing an o-stepped-progress instance manually
+
+Assuming that you have an HTML element on the page to represent your stepped progress:
+
+```js
+import SteppedProgress from 'o-stepped-progress';
+const steppedProgressElement = document.getElementById('my-stepped-progress');
+const mySteppedProgress = new SteppedProgress(steppedProgressElement);
+```
+
+If you want to initialise every stepped progress element on the page (based on the presence of the attribute: `data-o-component="o-stepped-progress"`):
+
+```js
+import SteppedProgress from 'o-stepped-progress';
+SteppedProgress.init();
+```
+
+#### Constructing o-stepped-progress instances automatically
+
+You can also rely on the `o.DOMContentLoaded` event to initialise all Origami components that have been included in your JavaScript. Either use [o-autoinit](https://github.com/Financial-Times/o-autoinit) or dispatch the event yourself once all of your page content has loaded:
+
+```js
+document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+```
+
+### Interacting with an o-stepped-progress instance
+
+Once you have stepped progress instances, you can interact with them using the methods below:
+
+  - `mySteppedProgress.getSteps()`: Get an array of the steps in the stepped progress component
+  - `mySteppedProgress.getCompletedSteps()`: Get an array of the steps that are completed
+  - `mySteppedProgress.getCurrent()`: Get the step marked as current
+  - `mySteppedProgress.isComplete()`: Get whether the stepped progress has been completed
+  - `mySteppedProgress.progress()`: Mark the current step as complete, and move onto the next step
+
+There is [full API documentation available in the Origami Registry](https://registry.origami.ft.com/components/o-stepped-progress/jsdoc).
 
 ### Sass
 

--- a/main.js
+++ b/main.js
@@ -1,3 +1,4 @@
+
 import SteppedProgress from './src/js/stepped-progress';
 
 const constructAll = function () {

--- a/src/js/stepped-progress-step.js
+++ b/src/js/stepped-progress-step.js
@@ -1,0 +1,219 @@
+
+/**
+ * Component class names.
+ *
+ * @access private
+ * @type {Object}
+ */
+const classNames = {
+	complete: 'o-stepped-progress__step--complete',
+	current: 'o-stepped-progress__step--current',
+	error: 'o-stepped-progress__step--error',
+	label: 'o-stepped-progress__label',
+	status: 'o-stepped-progress__status'
+};
+
+/**
+ * Component status texts mapped from states.
+ *
+ * @access private
+ * @type {Object}
+ */
+const statusTexts = {
+	complete: '(completed)',
+	current: '(current step)',
+	error: '(error)'
+};
+
+/**
+ * State class names as an array.
+ *
+ * @access private
+ * @type {Array}
+ */
+const stateClassNames = [
+	classNames.complete,
+	classNames.current,
+	classNames.error
+];
+
+/**
+ * Represents a step in a stepped progress component.
+ */
+class SteppedProgressStep {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @access public
+	 * @param {HTMLElement} stepElement - The step element in the DOM
+	 * @param {SteppedProgress} parent - The parent stepped progress instance
+	 */
+	constructor (stepElement, parent) {
+		this.stepElement = stepElement;
+		this.parent = parent;
+		this.labelElement = this._selectLabelElement();
+		this.statusElement = this._selectStatusElement();
+		this._setInitialStatusText();
+	}
+
+	/**
+	 * Get whether the step has the "complete" state.
+	 *
+	 * @access public
+	 * @returns {Boolean} Returns whether the step is complete.
+	 */
+	isComplete() {
+		return this.stepElement.classList.contains(classNames.complete);
+	}
+
+	/**
+	 * Get whether the step has the "current" state.
+	 *
+	 * @access public
+	 * @returns {Boolean} Returns whether the step is current.
+	 */
+	isCurrent() {
+		return this.stepElement.classList.contains(classNames.current);
+	}
+
+	/**
+	 * Get whether the step has the "error" state.
+	 *
+	 * @access public
+	 * @returns {Boolean} Returns whether the step has an error.
+	 */
+	isError() {
+		return this.stepElement.classList.contains(classNames.error);
+	}
+
+	/**
+	 * Get whether the step has no explicit state (and so is a future step).
+	 *
+	 * @access public
+	 * @returns {Boolean} Returns whether the step has no explicit state.
+	 */
+	isFuture() {
+		return (
+			!this.isComplete() &&
+			!this.isCurrent() &&
+			!this.isError()
+		);
+	}
+
+	/**
+	 * Set the step's state to "complete".
+	 *
+	 * @access public
+	 * @returns {void}
+	 */
+	markAsComplete() {
+		this._clearStateClasses();
+		this.stepElement.classList.add(classNames.complete);
+		this._setStatusText(statusTexts.complete);
+	}
+
+	/**
+	 * Set the step's state to "current".
+	 *
+	 * @access public
+	 * @returns {void}
+	 */
+	markAsCurrent() {
+		this._clearStateClasses();
+		this.stepElement.classList.add(classNames.current);
+		this._setStatusText(statusTexts.current);
+	}
+
+	/**
+	 * Set the step's state to "error".
+	 *
+	 * @access public
+	 * @returns {void}
+	 */
+	markAsError() {
+		this._clearStateClasses();
+		this.stepElement.classList.add(classNames.error);
+		this._setStatusText(statusTexts.error);
+	}
+
+	/**
+	 * Remove all states from the step (marking it as a future step).
+	 *
+	 * @access public
+	 * @returns {void}
+	 */
+	markAsFuture() {
+		this._clearStateClasses();
+		this._setStatusText();
+	}
+
+	/**
+	 * Get the step label HTML element.
+	 *
+	 * @access private
+	 * @returns {HTMLElement} Returns the step label HTML element.
+	 */
+	_selectLabelElement() {
+		return this.stepElement.querySelector(`.${classNames.label}`);
+	}
+
+	/**
+	 * Get the step status HTML element, creating it if it does not exist.
+	 *
+	 * @access private
+	 * @returns {HTMLElement} Returns the step status HTML element.
+	 */
+	_selectStatusElement() {
+		let statusElement = this.stepElement.querySelector(`.${classNames.status}`);
+		if (!statusElement) {
+			statusElement = document.createElement('span');
+			statusElement.classList.add(classNames.status);
+			this.labelElement.appendChild(statusElement);
+		}
+		return statusElement;
+	}
+
+	/**
+	 * Set the text of the step status element.
+	 *
+	 * @access private
+	 * @param {String} [statusText=''] - The text to set.
+	 * @returns {void}
+	 */
+	_setStatusText(statusText = '') {
+		this.statusElement.innerHTML = statusText;
+	}
+
+	/**
+	 * Set the initial status text based on the step state in the DOM.
+	 *
+	 * @access private
+	 * @returns {void}
+	 */
+	_setInitialStatusText() {
+		if (this.isComplete()) {
+			return this._setStatusText(statusTexts.complete);
+		}
+		if (this.isCurrent()) {
+			return this._setStatusText(statusTexts.current);
+		}
+		if (this.isError()) {
+			return this._setStatusText(statusTexts.error);
+		}
+		this._setStatusText();
+	}
+
+	/**
+	 * Clear all state classes from the step element.
+	 *
+	 * @access private
+	 * @returns {void}
+	 */
+	_clearStateClasses() {
+		this.stepElement.classList.remove(...stateClassNames);
+	}
+
+}
+
+export default SteppedProgressStep;

--- a/src/js/stepped-progress-step.js
+++ b/src/js/stepped-progress-step.js
@@ -211,7 +211,9 @@ class SteppedProgressStep {
 	 * @returns {void}
 	 */
 	_clearStateClasses() {
-		this.stepElement.classList.remove(...stateClassNames);
+		for (const className of stateClassNames) {
+			this.stepElement.classList.remove(className);
+		}
 	}
 
 }

--- a/src/js/stepped-progress.js
+++ b/src/js/stepped-progress.js
@@ -105,7 +105,7 @@ class SteppedProgress {
 	 * @returns {Boolean} Returns whether all steps are completed.
 	 */
 	isComplete() {
-		return (this.getCompletedSteps().length === this._steps.length);
+		return this._steps.every(step => step.isComplete());
 	}
 
 	/**

--- a/src/js/stepped-progress.js
+++ b/src/js/stepped-progress.js
@@ -1,24 +1,172 @@
 
+import SteppedProgressStep from './stepped-progress-step';
+
+/**
+ * Component class names.
+ *
+ * @access private
+ * @type {Object}
+ */
+const classNames = {
+	step: 'o-stepped-progress__step'
+};
+
+/**
+ * Represents a stepped progress component.
+ */
 class SteppedProgress {
 
 	/**
 	 * Class constructor.
-	 * @param {HTMLElement} [steppedProgressElement] - The component element in the DOM
-	 * @param {Object} [options={}] - An options object for configuring the component
+	 *
+	 * @access public
+	 * @param {HTMLElement} steppedProgressElement - The component element in the DOM.
+	 * @param {Object} [options={}] - An options object for configuring the component.
 	 */
-	constructor (steppedProgressElement, opts) {
+	constructor (steppedProgressElement, options) {
 		this.steppedProgressElement = steppedProgressElement;
 		this.options = Object.assign({}, {
 			// TODO
-		}, opts || SteppedProgress.getDataAttributes(steppedProgressElement));
+		}, options || SteppedProgress.getDataAttributes(steppedProgressElement));
+		this._constructSteps();
 	}
 
 	/**
-	 * Get the data attributes from the stepped progress element. If the message is being set up
-	 * declaratively, this method is used to extract the data attributes from the DOM.
-	 * @param {HTMLElement} steppedProgressElement - The component element in the DOM
+	 * Get an array of steps.
+	 *
+	 * @access public
+	 * @returns {Array<SteppedProgressStep>} Returns an array of steps.
 	 */
-	static getDataAttributes (steppedProgressElement) {
+	getSteps() {
+		return [...this._steps];
+	}
+
+	/**
+	 * Get an array of steps with a "completed" status.
+	 *
+	 * @access public
+	 * @returns {Array<SteppedProgressStep>} Returns an array of steps.
+	 */
+	getCompletedSteps() {
+		return this._steps.filter(step => step.isComplete());
+	}
+
+	/**
+	 * Get whether a step exists at a given index (0-based).
+	 *
+	 * @access public
+	 * @param {Number} index - The index to check.
+	 * @returns {Boolean} Returns whether a step exists at a given index.
+	 */
+	hasStepAtIndex(index) {
+		return Boolean(this._steps[index]);
+	}
+
+	/**
+	 * Get the step at a given index (0-based).
+	 *
+	 * @access public
+	 * @param {Number} index - The index of the step to get.
+	 * @returns {SteppedProgressStep} Returns the step at the given index.
+	 * @throws {Error} Will throw an error if there is no step at the given index. Use {@link SteppedProgress#hasStepAtIndex} to check.
+	 */
+	getStepAtIndex(index) {
+		if (!this.hasStepAtIndex(index)) {
+			throw new Error(`No step at index: ${index}`);
+		}
+		return this._steps[index];
+	}
+
+	/**
+	 * Get the step which has the "current" state. If there are multiple steps with this state then
+	 * the last one will be returned.
+	 *
+	 * @access public
+	 * @returns {SteppedProgressStep} Returns the current step.
+	 */
+	getCurrentStep() {
+		return this._steps.filter(step => step.isCurrent()).pop();
+	}
+
+	/**
+	 * Get the last step in the stepped progress.
+	 *
+	 * @access public
+	 * @returns {SteppedProgressStep} Returns the last step.
+	 */
+	getLastStep() {
+		return this._steps[this._steps.length - 1];
+	}
+
+	/**
+	 * Get whether all steps have the "completed" state.
+	 *
+	 * @access public
+	 * @returns {Boolean} Returns whether all steps are completed.
+	 */
+	isComplete() {
+		return (this.getCompletedSteps().length === this._steps.length);
+	}
+
+	/**
+	 * Get the next future step (a step which does not have the "current", "complete", or "error"
+	 * states). If no such step exists, the last step will be returned.
+	 *
+	 * @access public
+	 * @returns {SteppedProgressStep} Returns the next step.
+	 */
+	getNextStep() {
+		if (!this.isComplete()) {
+			return this._steps.find(step => step.isFuture()) || this.getLastStep();
+		}
+		return this.getLastStep();
+	}
+
+	/**
+	 * Mark the current step as "complete" and then mark the next step as "current". If all steps
+	 * have the "complete" state then this method does nothing.
+	 *
+	 * @access public
+	 * @returns {void}
+	 */
+	progress() {
+		if (!this.isComplete()) {
+			const currentStep = this.getCurrentStep();
+			if (currentStep) {
+				currentStep.markAsComplete();
+			}
+		}
+		if (!this.isComplete()) {
+			this.getNextStep().markAsCurrent();
+		}
+	}
+
+	/**
+	 * Construct step instances and store them on the  `_steps` and `_stepElementInstanceMap` properties.
+	 *
+	 * @access private
+	 * @returns {void}
+	 */
+	_constructSteps() {
+		const elements = this.steppedProgressElement.querySelectorAll(`.${classNames.step}`);
+		this._stepElementInstanceMap = new Map([...elements].map(element => {
+			return [
+				element,
+				new SteppedProgressStep(element, this)
+			];
+		}));
+		this._steps = [...this._stepElementInstanceMap.values()];
+	}
+
+	/**
+	 * Get the data attributes from the stepped progress element. If the component is being set up
+	 * declaratively, this method is used to extract the data attributes from the DOM.
+	 *
+	 * @access public
+	 * @param {HTMLElement} steppedProgressElement - The component element in the DOM
+	 * @returns {Object} Returns an options object constructed from the DOM.
+	 */
+	static getDataAttributes(steppedProgressElement) {
 		if (!(steppedProgressElement instanceof HTMLElement)) {
 			return {};
 		}
@@ -46,10 +194,13 @@ class SteppedProgress {
 
 	/**
 	 * Initialise stepped progress component.
+	 *
+	 * @access public
 	 * @param {(HTMLElement|String)} rootElement - The root element to intialise the component in, or a CSS selector for the root element
 	 * @param {Object} [options={}] - An options object for configuring the component
+	 * @returns {(SteppedProgress|Array<SteppedProgress>)} Returns a stepped progress instance, or an array of instances.
 	 */
-	static init (rootEl, opts) {
+	static init(rootEl, options) {
 		if (!rootEl) {
 			rootEl = document.body;
 		}
@@ -57,9 +208,9 @@ class SteppedProgress {
 			rootEl = document.querySelector(rootEl);
 		}
 		if (rootEl instanceof HTMLElement && rootEl.matches('[data-o-component=o-stepped-progress]')) {
-			return new SteppedProgress(rootEl, opts);
+			return new SteppedProgress(rootEl, options);
 		}
-		return Array.from(rootEl.querySelectorAll('[data-o-component="o-stepped-progress"]'), rootEl => new SteppedProgress(rootEl, opts));
+		return Array.from(rootEl.querySelectorAll('[data-o-component="o-stepped-progress"]'), rootEl => new SteppedProgress(rootEl, options));
 	}
 }
 

--- a/src/js/stepped-progress.js
+++ b/src/js/stepped-progress.js
@@ -142,20 +142,14 @@ class SteppedProgress {
 	}
 
 	/**
-	 * Construct step instances and store them on the  `_steps` and `_stepElementInstanceMap` properties.
+	 * Construct step instances and store them on the `_steps` property.
 	 *
 	 * @access private
 	 * @returns {void}
 	 */
 	_constructSteps() {
 		const elements = this.steppedProgressElement.querySelectorAll(`.${classNames.step}`);
-		this._stepElementInstanceMap = new Map([...elements].map(element => {
-			return [
-				element,
-				new SteppedProgressStep(element, this)
-			];
-		}));
-		this._steps = [...this._stepElementInstanceMap.values()];
+		this._steps = [...elements].map(element => new SteppedProgressStep(element, this));
 	}
 
 	/**

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -1,33 +1,47 @@
-let sandboxEl;
 
-function createSandbox() {
-	if (document.querySelector('.sandbox')) {
-		sandboxEl = document.querySelector('.sandbox');
-	} else {
-		sandboxEl = document.createElement('div');
-		sandboxEl.setAttribute('class', 'sandbox');
-		document.body.appendChild(sandboxEl);
-	}
-}
+const testMarkup = {
 
-function reset() {
-	sandboxEl.innerHTML = '';
-}
+	steppedProgress: `
+		<div class="o-stepped-progress" data-o-component="o-stepped-progress">
+			<ol class="o-stepped-progress__steps">
+				<li>
+					<a href="#step-1" class="o-stepped-progress__step o-stepped-progress__step--complete">
+						<span class="o-stepped-progress__label">
+							Step 1 <span class="o-stepped-progress__status">(completed)</span>
+						</span>
+					</a>
+				</li>
+				<li>
+					<a href="#step-2" class="o-stepped-progress__step o-stepped-progress__step--current">
+						<span class="o-stepped-progress__label">
+							Step 2 <span class="o-stepped-progress__status">(current step)</span>
+						</span>
+					</a>
+				</li>
+				<li>
+					<span class="o-stepped-progress__step">
+						<span class="o-stepped-progress__label">Step 3</span>
+					</span>
+				</li>
+				<li>
+					<span class="o-stepped-progress__step">
+						<span class="o-stepped-progress__label">Step 4</span>
+					</span>
+				</li>
+			</ol>
+		</div>
+	`,
 
-function insert(html) {
-	createSandbox();
-	sandboxEl.innerHTML = html;
-}
-
-function htmlCode () {
-	const html = `<div>
-		<div class="o-stepped-progress" data-o-component="o-stepped-progress" id="element"></div>
-	</div>
-	`;
-	insert(html);
-}
+	steppedProgressStep: `
+		<a href="#" class="o-stepped-progress__step">
+			<span class="o-stepped-progress__label">
+				Mock Step
+				<span class="o-stepped-progress__status">mock status</span>
+			</span>
+		</a>
+	`
+};
 
 export {
-	htmlCode,
-	reset
+	testMarkup
 };

--- a/test/stepped-progress-step.test.js
+++ b/test/stepped-progress-step.test.js
@@ -1,0 +1,314 @@
+/* eslint-env mocha */
+
+import * as assert from 'proclaim';
+import * as fixtures from './helpers/fixtures';
+import sinon from 'sinon/pkg/sinon';
+import SteppedProgressStep from '../src/js/stepped-progress-step';
+
+describe('src/js/stepped-progress-step', () => {
+
+	it('exports a class constructor', () => {
+		assert.isFunction(SteppedProgressStep);
+		assert.throws(SteppedProgressStep, TypeError);
+	});
+
+	describe('new SteppedProgressStep(stepElement, parent)', () => {
+		let mockLabelElement;
+		let mockParent;
+		let mockStatusElement;
+		let mockStepElement;
+		let step;
+
+		beforeEach(() => {
+			const sandbox = document.createElement('div');
+			sandbox.innerHTML = fixtures.testMarkup.steppedProgressStep;
+			mockStepElement = sandbox.querySelector('.o-stepped-progress__step');
+			mockLabelElement = mockStepElement.querySelector('.o-stepped-progress__label');
+			mockStatusElement = mockStepElement.querySelector('.o-stepped-progress__status');
+			mockParent = {};
+			step = new SteppedProgressStep(mockStepElement, mockParent);
+		});
+
+		describe('.stepElement', () => {
+			it('is set to the `stepElement` that was passed into the constructor', () => {
+				assert.strictEqual(step.stepElement, mockStepElement);
+			});
+		});
+
+		describe('.parent', () => {
+			it('is set to the `parent` that was passed into the constructor', () => {
+				assert.strictEqual(step.parent, mockParent);
+			});
+		});
+
+		describe('.labelElement', () => {
+			it('is set to the label element found inside `stepElement`', () => {
+				assert.strictEqual(step.labelElement, mockLabelElement);
+			});
+		});
+
+		describe('.statusElement', () => {
+
+			it('is set to the status element found inside `stepElement`', () => {
+				assert.strictEqual(step.statusElement, mockStatusElement);
+			});
+
+			it('is emptied of any text', () => {
+				assert.strictEqual(step.statusElement.textContent.trim(), '');
+			});
+
+		});
+
+		describe('.isComplete()', () => {
+
+			describe('when the step has the "complete" modifier class', () => {
+				it('returns `true`', () => {
+					mockStepElement.classList.add('o-stepped-progress__step--complete');
+					assert.isTrue(step.isComplete());
+				});
+			});
+
+			describe('when the step does not have the "complete" modifier class', () => {
+				it('returns `false`', () => {
+					mockStepElement.classList.remove('o-stepped-progress__step--complete');
+					assert.isFalse(step.isComplete());
+				});
+			});
+
+		});
+
+		describe('.isCurrent()', () => {
+
+			describe('when the step has the "current" modifier class', () => {
+				it('returns `true`', () => {
+					mockStepElement.classList.add('o-stepped-progress__step--current');
+					assert.isTrue(step.isCurrent());
+				});
+			});
+
+			describe('when the step does not have the "current" modifier class', () => {
+				it('returns `false`', () => {
+					mockStepElement.classList.remove('o-stepped-progress__step--current');
+					assert.isFalse(step.isCurrent());
+				});
+			});
+
+		});
+
+		describe('.isError()', () => {
+
+			describe('when the step has the "error" modifier class', () => {
+				it('returns `true`', () => {
+					mockStepElement.classList.add('o-stepped-progress__step--error');
+					assert.isTrue(step.isError());
+				});
+			});
+
+			describe('when the step does not have the "error" modifier class', () => {
+				it('returns `false`', () => {
+					mockStepElement.classList.remove('o-stepped-progress__step--error');
+					assert.isFalse(step.isError());
+				});
+			});
+
+		});
+
+		describe('.isFuture()', () => {
+
+			beforeEach(() => {
+				sinon.stub(step, 'isComplete').returns(false);
+				sinon.stub(step, 'isCurrent').returns(false);
+				sinon.stub(step, 'isError').returns(false);
+			});
+
+			afterEach(() => {
+				step.isComplete.restore();
+				step.isCurrent.restore();
+				step.isError.restore();
+			});
+
+			describe('when the step has no explicit state', () => {
+				it('returns `true`', () => {
+					assert.isTrue(step.isFuture());
+				});
+			});
+
+			describe('when the step is considered to be in a "complete" state', () => {
+				it('returns `false`', () => {
+					step.isComplete.returns(true);
+					assert.isFalse(step.isFuture());
+				});
+			});
+
+			describe('when the step is considered to be in a "current" state', () => {
+				it('returns `false`', () => {
+					step.isCurrent.returns(true);
+					assert.isFalse(step.isFuture());
+				});
+			});
+
+			describe('when the step is considered to be in a "error" state', () => {
+				it('returns `false`', () => {
+					step.isError.returns(true);
+					assert.isFalse(step.isFuture());
+				});
+			});
+
+		});
+
+		describe('.markAsComplete()', () => {
+
+			beforeEach(() => {
+				mockStepElement.classList.add('o-stepped-progress__step--current');
+				mockStepElement.classList.add('o-stepped-progress__step--error');
+				step.markAsComplete();
+			});
+
+			it('removes any other status classes', () => {
+				assert.isFalse(mockStepElement.classList.contains('o-stepped-progress__step--current'));
+				assert.isFalse(mockStepElement.classList.contains('o-stepped-progress__step--error'));
+			});
+
+			it('adds the "complete" status class', () => {
+				assert.isTrue(mockStepElement.classList.contains('o-stepped-progress__step--complete'));
+			});
+
+			it('sets the status element text to indicate the new state', () => {
+				assert.strictEqual(step.statusElement.textContent.trim(), '(completed)');
+			});
+
+		});
+
+		describe('.markAsCurrent()', () => {
+
+			beforeEach(() => {
+				mockStepElement.classList.add('o-stepped-progress__step--complete');
+				mockStepElement.classList.add('o-stepped-progress__step--error');
+				step.markAsCurrent();
+			});
+
+			it('removes any other status classes', () => {
+				assert.isFalse(mockStepElement.classList.contains('o-stepped-progress__step--complete'));
+				assert.isFalse(mockStepElement.classList.contains('o-stepped-progress__step--error'));
+			});
+
+			it('adds the "current" status class', () => {
+				assert.isTrue(mockStepElement.classList.contains('o-stepped-progress__step--current'));
+			});
+
+			it('sets the status element text to indicate the new state', () => {
+				assert.strictEqual(step.statusElement.textContent.trim(), '(current step)');
+			});
+
+		});
+
+		describe('.markAsError()', () => {
+
+			beforeEach(() => {
+				mockStepElement.classList.add('o-stepped-progress__step--complete');
+				mockStepElement.classList.add('o-stepped-progress__step--current');
+				step.markAsError();
+			});
+
+			it('removes any other status classes', () => {
+				assert.isFalse(mockStepElement.classList.contains('o-stepped-progress__step--complete'));
+				assert.isFalse(mockStepElement.classList.contains('o-stepped-progress__step--current'));
+			});
+
+			it('adds the "error" status class', () => {
+				assert.isTrue(mockStepElement.classList.contains('o-stepped-progress__step--error'));
+			});
+
+			it('sets the status element text to indicate the new state', () => {
+				assert.strictEqual(step.statusElement.textContent.trim(), '(error)');
+			});
+
+		});
+
+		describe('.markAsFuture()', () => {
+
+			beforeEach(() => {
+				mockStepElement.classList.add('o-stepped-progress__step--complete');
+				mockStepElement.classList.add('o-stepped-progress__step--current');
+				mockStepElement.classList.add('o-stepped-progress__step--error');
+				mockStatusElement.textContent = 'Mock Status';
+				step.markAsFuture();
+			});
+
+			it('removes all status classes', () => {
+				assert.isFalse(mockStepElement.classList.contains('o-stepped-progress__step--complete'));
+				assert.isFalse(mockStepElement.classList.contains('o-stepped-progress__step--current'));
+				assert.isFalse(mockStepElement.classList.contains('o-stepped-progress__step--error'));
+			});
+
+			it('clears the status element text', () => {
+				assert.strictEqual(step.statusElement.textContent.trim(), '');
+			});
+
+		});
+
+		describe('when the status element does not exist', () => {
+
+			beforeEach(() => {
+				mockStatusElement.remove();
+				step = new SteppedProgressStep(mockStepElement, mockParent);
+			});
+
+			it('is created', () => {
+				assert.isDefined(step.statusElement);
+				assert.strictEqual(step.statusElement.outerHTML, '<span class="o-stepped-progress__status"></span>');
+			});
+
+		});
+
+		describe('when the initial state of the step is "complete"', () => {
+
+			beforeEach(() => {
+				mockStatusElement.textContent = '';
+				mockStepElement.classList.add('o-stepped-progress__step--complete');
+				step = new SteppedProgressStep(mockStepElement, mockParent);
+			});
+
+			describe('.statusElement', () => {
+				it('has its text set to indicate the initial state', () => {
+					assert.strictEqual(step.statusElement.textContent.trim(), '(completed)');
+				});
+			});
+
+		});
+
+		describe('when the initial state of the step is "current"', () => {
+
+			beforeEach(() => {
+				mockStatusElement.textContent = '';
+				mockStepElement.classList.add('o-stepped-progress__step--current');
+				step = new SteppedProgressStep(mockStepElement, mockParent);
+			});
+
+			describe('.statusElement', () => {
+				it('has its text set to indicate the initial state', () => {
+					assert.strictEqual(step.statusElement.textContent.trim(), '(current step)');
+				});
+			});
+
+		});
+
+		describe('when the initial state of the step is "error"', () => {
+
+			beforeEach(() => {
+				mockStatusElement.textContent = '';
+				mockStepElement.classList.add('o-stepped-progress__step--error');
+				step = new SteppedProgressStep(mockStepElement, mockParent);
+			});
+
+			describe('.statusElement', () => {
+				it('has its text set to indicate the initial state', () => {
+					assert.strictEqual(step.statusElement.textContent.trim(), '(error)');
+				});
+			});
+
+		});
+
+	});
+
+});

--- a/test/stepped-progress.test.js
+++ b/test/stepped-progress.test.js
@@ -484,50 +484,6 @@ describe('src/js/stepped-progress', () => {
 
 		});
 
-		describe('._stepElementInstanceMap', () => {
-
-			it('is a map of elements to `SteppedProgressStep` instances', () => {
-				assert.instanceOf(steppedProgress._stepElementInstanceMap, Map);
-				for (const key of steppedProgress._stepElementInstanceMap.keys()) {
-					assert.instanceOf(key, HTMLElement);
-				}
-				for (const key of steppedProgress._stepElementInstanceMap.values()) {
-					assert.instanceOf(key, SteppedProgressStep);
-				}
-			});
-
-			describe('each entry in the map', () => {
-				let stepElements;
-
-				beforeEach(() => {
-					stepElements = mockSteppedProgressElement.querySelectorAll('.o-stepped-progress__step');
-				});
-
-				// The length of this array is based on mock HTML
-				// found in: ./helpers/fixtures.js
-				for (const index of Array(4).keys()) {
-					describe(`map value for step element #${index}`, () => {
-						let value;
-
-						beforeEach(() => {
-							value = steppedProgress._stepElementInstanceMap.get(stepElements[index]);
-						});
-
-						it('has a `.stepElement` property set to the corresponding HTML element', () => {
-							assert.strictEqual(value.stepElement, stepElements[index]);
-						});
-
-						it('has a `.parent` property set to the `SteppedProgress` instance', () => {
-							assert.strictEqual(value.parent, steppedProgress);
-						});
-
-					});
-				}
-
-			});
-
-		});
-
 	});
 
 });

--- a/test/stepped-progress.test.js
+++ b/test/stepped-progress.test.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* eslint-disable no-loop-func */
 
 import * as assert from 'proclaim';
 import * as fixtures from './helpers/fixtures';

--- a/test/stepped-progress.test.js
+++ b/test/stepped-progress.test.js
@@ -1,56 +1,530 @@
-
 /* eslint-env mocha */
 
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+import * as assert from 'proclaim';
 import * as fixtures from './helpers/fixtures';
+import sinon from 'sinon/pkg/sinon';
+import SteppedProgress from '../src/js/stepped-progress';
+import SteppedProgressStep from '../src/js/stepped-progress-step';
 
-import SteppedProgress from '../main';
+sinon.assert.expose(assert, {
+	includeFail: false,
+	prefix: ''
+});
 
-describe('SteppedProgress', () => {
+describe('src/js/stepped-progress', () => {
 
-	it('is defined', () => {
-		proclaim.equal(typeof SteppedProgress, 'function');
+	it('exports a class constructor', () => {
+		assert.isFunction(SteppedProgress);
+		assert.throws(SteppedProgress, TypeError);
 	});
 
-	it('has a static init method', () => {
-		proclaim.equal(typeof SteppedProgress.init, 'function');
-	});
-
-	it('should autoinitialize', (done) => {
-		const initSpy = sinon.spy(SteppedProgress, 'init');
-		document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
-		setTimeout(function(){
-			proclaim.equal(initSpy.called, true);
-			initSpy.restore();
-			done();
-		}, 100);
-	});
-
-	it('should not autoinitialize when the event is not dispached', () => {
-		const initSpy = sinon.spy(SteppedProgress, 'init');
-		proclaim.equal(initSpy.called, false);
-	});
-
-	describe('should create a new', () => {
+	describe('new SteppedProgress(steppedProgressElement)', () => {
+		let mockDataAttributeOptions;
+		let mockSteppedProgressElement;
+		let steppedProgress;
 
 		beforeEach(() => {
-			fixtures.htmlCode();
+			mockDataAttributeOptions = {
+				isMockDataAttributeOptions: true
+			};
+			sinon.stub(SteppedProgress, 'getDataAttributes').returns(mockDataAttributeOptions);
+
+			const sandbox = document.createElement('div');
+			sandbox.innerHTML = fixtures.testMarkup.steppedProgress;
+			mockSteppedProgressElement = sandbox.querySelector('.o-stepped-progress');
+
+			steppedProgress = new SteppedProgress(mockSteppedProgressElement);
 		});
 
 		afterEach(() => {
-			fixtures.reset();
+			SteppedProgress.getDataAttributes.restore();
 		});
 
-		it('component array when initialized', () => {
-			const boilerplate = SteppedProgress.init();
-			proclaim.equal(boilerplate instanceof Array, true);
-			proclaim.equal(boilerplate[0] instanceof SteppedProgress, true);
+		it('fetches options set via HTML data attributes', () => {
+			assert.calledOnce(SteppedProgress.getDataAttributes);
+			assert.calledWithExactly(SteppedProgress.getDataAttributes, mockSteppedProgressElement);
 		});
 
-		it('single component when initialized with a root element', () => {
-			const boilerplate = SteppedProgress.init('#element');
-			proclaim.equal(boilerplate instanceof SteppedProgress, true);
+		describe('.options', () => {
+			it('is a defaulted options object', () => {
+				assert.isObject(steppedProgress.options);
+				assert.deepEqual(steppedProgress.options, {
+					isMockDataAttributeOptions: true
+				});
+				assert.notStrictEqual(steppedProgress.options, mockDataAttributeOptions);
+			});
+		});
+
+		describe('.steppedProgressElement', () => {
+			it('is set to the `steppedProgressElement` that was passed into the constructor', () => {
+				assert.strictEqual(steppedProgress.steppedProgressElement, mockSteppedProgressElement);
+			});
+		});
+
+		describe('.getSteps()', () => {
+			let returnValue;
+
+			beforeEach(() => {
+				steppedProgress._steps = ['a', 'b', 'c'];
+				returnValue = steppedProgress.getSteps();
+			});
+
+			it('returns an array of all of the steps', () => {
+				assert.deepEqual(returnValue, steppedProgress._steps);
+			});
+
+			it('does not return the exact array instance used internally', () => {
+				assert.notStrictEqual(returnValue, steppedProgress._steps);
+			});
+
+		});
+
+		describe('.getCompletedSteps()', () => {
+			let returnValue;
+
+			beforeEach(() => {
+				steppedProgress._steps = [
+					{
+						isComplete: sinon.stub().returns(true)
+					},
+					{
+						isComplete: sinon.stub().returns(false)
+					},
+					{
+						isComplete: sinon.stub().returns(true)
+					},
+					{
+						isComplete: sinon.stub().returns(false)
+					}
+				];
+				returnValue = steppedProgress.getCompletedSteps();
+			});
+
+			it('returns an array of all of the steps which are completed', () => {
+				assert.deepEqual(returnValue, [
+					steppedProgress._steps[0],
+					steppedProgress._steps[2]
+				]);
+			});
+
+			it('does not return the exact array instance used internally', () => {
+				assert.notStrictEqual(returnValue, steppedProgress._steps);
+			});
+
+		});
+
+		describe('.hasStepAtIndex(index)', () => {
+
+			beforeEach(() => {
+				steppedProgress._steps = ['a', 'b', 'c'];
+			});
+
+			describe('when a step exists at `index`', () => {
+				it('returns `true`', () => {
+					assert.isTrue(steppedProgress.hasStepAtIndex(1));
+				});
+			});
+
+			describe('when a step does not exist at `index`', () => {
+				it('returns `false`', () => {
+					assert.isFalse(steppedProgress.hasStepAtIndex(10));
+				});
+			});
+
+		});
+
+		describe('.getStepAtIndex(index)', () => {
+
+			beforeEach(() => {
+				steppedProgress._steps = ['a', 'b', 'c'];
+			});
+
+			describe('when a step exists at `index`', () => {
+				it('returns the step at the given index', () => {
+					assert.strictEqual(steppedProgress.getStepAtIndex(1), 'b');
+				});
+			});
+
+			describe('when a step does not exist at `index`', () => {
+				it('throws an error', () => {
+					assert.throws(() => steppedProgress.getStepAtIndex(10), /no step at index: 10/i);
+				});
+			});
+
+		});
+
+		describe('.getCurrentStep()', () => {
+
+			describe('when there is at least one step with a "current" status', () => {
+
+				beforeEach(() => {
+					steppedProgress._steps = [
+						{
+							isCurrent: sinon.stub().returns(false)
+						},
+						{
+							isCurrent: sinon.stub().returns(true)
+						},
+						{
+							isCurrent: sinon.stub().returns(false)
+						},
+						{
+							isCurrent: sinon.stub().returns(true)
+						},
+						{
+							isCurrent: sinon.stub().returns(false)
+						}
+					];
+				});
+
+				it('returns the last step with a "current" status', () => {
+					assert.strictEqual(steppedProgress.getCurrentStep(), steppedProgress._steps[3]);
+				});
+
+			});
+
+			describe('when there is no current step', () => {
+
+				beforeEach(() => {
+					steppedProgress._steps = [
+						{
+							isCurrent: sinon.stub().returns(false)
+						}
+					];
+				});
+
+				it('returns `undefined`', () => {
+					assert.isUndefined(steppedProgress.getCurrentStep());
+				});
+
+			});
+
+		});
+
+		describe('.getLastStep()', () => {
+
+			beforeEach(() => {
+				steppedProgress._steps = ['a', 'b', 'c'];
+			});
+
+			it('returns the last step', () => {
+				assert.strictEqual(steppedProgress.getLastStep(), 'c');
+			});
+
+		});
+
+		describe('.isComplete()', () => {
+
+			describe('when all steps have the "complete" status', () => {
+
+				beforeEach(() => {
+					steppedProgress._steps = [
+						{
+							isComplete: sinon.stub().returns(true)
+						},
+						{
+							isComplete: sinon.stub().returns(true)
+						},
+						{
+							isComplete: sinon.stub().returns(true)
+						}
+					];
+				});
+
+				it('returns `true`', () => {
+					assert.isTrue(steppedProgress.isComplete());
+				});
+
+			});
+
+			describe('when not all steps have the "complete" status', () => {
+
+				beforeEach(() => {
+					steppedProgress._steps = [
+						{
+							isComplete: sinon.stub().returns(true)
+						},
+						{
+							isComplete: sinon.stub().returns(false)
+						},
+						{
+							isComplete: sinon.stub().returns(true)
+						}
+					];
+				});
+
+				it('returns `false`', () => {
+					assert.isFalse(steppedProgress.isComplete());
+				});
+
+			});
+
+		});
+
+		describe('.getNextStep()', () => {
+
+			beforeEach(() => {
+				sinon.stub(steppedProgress, 'getLastStep');
+				sinon.stub(steppedProgress, 'isComplete');
+			});
+
+			afterEach(() => {
+				steppedProgress.getLastStep.restore();
+				steppedProgress.isComplete.restore();
+			});
+
+			describe('when the stepped progress is not complete', () => {
+
+				beforeEach(() => {
+					steppedProgress.isComplete.returns(false);
+				});
+
+				describe('and there are steps without a status', () => {
+
+					beforeEach(() => {
+						steppedProgress._steps = [
+							{
+								isFuture: sinon.stub().returns(false)
+							},
+							{
+								isFuture: sinon.stub().returns(true)
+							},
+							{
+								isFuture: sinon.stub().returns(true)
+							}
+						];
+					});
+
+					it('returns the next step which has no status', () => {
+						assert.strictEqual(steppedProgress.getNextStep(), steppedProgress._steps[1]);
+					});
+
+				});
+
+				describe('and there are no steps without a status', () => {
+
+					beforeEach(() => {
+						steppedProgress.getLastStep.returns('mock last');
+						steppedProgress._steps = [
+							{
+								isFuture: sinon.stub().returns(false)
+							},
+							{
+								isFuture: sinon.stub().returns(false)
+							},
+							{
+								isFuture: sinon.stub().returns(false)
+							}
+						];
+					});
+
+					it('returns the last step', () => {
+						assert.strictEqual(steppedProgress.getNextStep(), 'mock last');
+					});
+
+				});
+
+			});
+
+			describe('when the stepped progress is complete', () => {
+
+				beforeEach(() => {
+					steppedProgress.isComplete.returns(true);
+					steppedProgress.getLastStep.returns('mock last');
+					steppedProgress._steps = ['a', 'b', 'c'];
+				});
+
+				it('returns the last step', () => {
+					assert.strictEqual(steppedProgress.getNextStep(), 'mock last');
+				});
+
+			});
+
+		});
+
+		describe('.progress()', () => {
+			let mockCurrentStep;
+			let mockNextStep;
+
+			beforeEach(() => {
+				mockCurrentStep = {
+					markAsComplete: sinon.stub()
+				};
+				mockNextStep = {
+					markAsCurrent: sinon.stub()
+				};
+				sinon.stub(steppedProgress, 'getCurrentStep').returns(mockCurrentStep);
+				sinon.stub(steppedProgress, 'getNextStep').returns(mockNextStep);
+				sinon.stub(steppedProgress, 'isComplete');
+			});
+
+			afterEach(() => {
+				steppedProgress.getCurrentStep.restore();
+				steppedProgress.getNextStep.restore();
+				steppedProgress.isComplete.restore();
+			});
+
+			describe('when the stepped progress is not complete, and there is a current and next step', () => {
+
+				beforeEach(() => {
+					steppedProgress.isComplete.onCall(0).returns(false);
+					steppedProgress.isComplete.onCall(1).returns(false);
+					steppedProgress.progress();
+				});
+
+				it('marks the current step as complete', () => {
+					assert.calledOnce(steppedProgress.getCurrentStep);
+					assert.calledOnce(mockCurrentStep.markAsComplete);
+				});
+
+				it('marks the next step as current', () => {
+					assert.calledOnce(steppedProgress.getNextStep);
+					assert.calledOnce(mockNextStep.markAsCurrent);
+				});
+
+			});
+
+			describe('when the stepped progress is not complete, and the current step is the last step', () => {
+
+				beforeEach(() => {
+					steppedProgress.isComplete.onCall(0).returns(false);
+					steppedProgress.isComplete.onCall(1).returns(true);
+					steppedProgress.progress();
+				});
+
+				it('marks the current step as complete', () => {
+					assert.calledOnce(steppedProgress.getCurrentStep);
+					assert.calledOnce(mockCurrentStep.markAsComplete);
+				});
+
+				it('does not mark the next step as current', () => {
+					assert.notCalled(steppedProgress.getNextStep);
+					assert.notCalled(mockNextStep.markAsCurrent);
+				});
+
+			});
+
+			describe('when the stepped progress is not complete, but there is no current step', () => {
+
+				beforeEach(() => {
+					steppedProgress.getCurrentStep.returns(undefined);
+					steppedProgress.isComplete.onCall(0).returns(false);
+					steppedProgress.isComplete.onCall(1).returns(false);
+					steppedProgress.progress();
+				});
+
+				it('does not mark the current step as complete', () => {
+					assert.calledOnce(steppedProgress.getCurrentStep);
+					assert.notCalled(mockCurrentStep.markAsComplete);
+				});
+
+				it('marks the next step as current', () => {
+					assert.calledOnce(steppedProgress.getNextStep);
+					assert.calledOnce(mockNextStep.markAsCurrent);
+				});
+
+			});
+
+			describe('when the stepped progress is complete', () => {
+
+				beforeEach(() => {
+					steppedProgress.isComplete.onCall(0).returns(true);
+					steppedProgress.isComplete.onCall(1).returns(true);
+					steppedProgress.progress();
+				});
+
+				it('does not mark the current step as complete', () => {
+					assert.notCalled(steppedProgress.getCurrentStep);
+					assert.notCalled(mockCurrentStep.markAsComplete);
+				});
+
+				it('does not mark the next step as current', () => {
+					assert.notCalled(steppedProgress.getNextStep);
+					assert.notCalled(mockNextStep.markAsCurrent);
+				});
+
+			});
+
+		});
+
+		describe('._steps', () => {
+
+			it('is an array of `SteppedProgressStep` instances', () => {
+				assert.isArray(steppedProgress._steps);
+				for (const step of steppedProgress._steps) {
+					assert.instanceOf(step, SteppedProgressStep);
+				}
+			});
+
+			describe('each `SteppedProgressStep` instance', () => {
+				let stepElements;
+
+				beforeEach(() => {
+					stepElements = mockSteppedProgressElement.querySelectorAll('.o-stepped-progress__step');
+				});
+
+				// The length of this array is based on mock HTML
+				// found in: ./helpers/fixtures.js
+				for (const index of Array(4).keys()) {
+					describe(`\`SteppedProgressStep\` instance #${index}`, () => {
+
+						it('has a `.stepElement` property set to the corresponding HTML element', () => {
+							assert.strictEqual(steppedProgress._steps[index].stepElement, stepElements[index]);
+						});
+
+						it('has a `.parent` property set to the `SteppedProgress` instance', () => {
+							assert.strictEqual(steppedProgress._steps[index].parent, steppedProgress);
+						});
+
+					});
+				}
+
+			});
+
+		});
+
+		describe('._stepElementInstanceMap', () => {
+
+			it('is a map of elements to `SteppedProgressStep` instances', () => {
+				assert.instanceOf(steppedProgress._stepElementInstanceMap, Map);
+				for (const key of steppedProgress._stepElementInstanceMap.keys()) {
+					assert.instanceOf(key, HTMLElement);
+				}
+				for (const key of steppedProgress._stepElementInstanceMap.values()) {
+					assert.instanceOf(key, SteppedProgressStep);
+				}
+			});
+
+			describe('each entry in the map', () => {
+				let stepElements;
+
+				beforeEach(() => {
+					stepElements = mockSteppedProgressElement.querySelectorAll('.o-stepped-progress__step');
+				});
+
+				// The length of this array is based on mock HTML
+				// found in: ./helpers/fixtures.js
+				for (const index of Array(4).keys()) {
+					describe(`map value for step element #${index}`, () => {
+						let value;
+
+						beforeEach(() => {
+							value = steppedProgress._stepElementInstanceMap.get(stepElements[index]);
+						});
+
+						it('has a `.stepElement` property set to the corresponding HTML element', () => {
+							assert.strictEqual(value.stepElement, stepElements[index]);
+						});
+
+						it('has a `.parent` property set to the `SteppedProgress` instance', () => {
+							assert.strictEqual(value.parent, steppedProgress);
+						});
+
+					});
+				}
+
+			});
+
 		});
 
 	});


### PR DESCRIPTION
This adds some fairly minimal JavaScript to allow for users to interact
with stepped progress. The main use case is progressing the steps,
marking the current step as complete and the next step as current.

It's also possible to directly manipulate each step which caters for
moving backwards through the stepped progress. We can provide
convenience methods for this use case later if we need to.

The best way to see how this works is probably to look at the README
changes first. There's also full JSDoc for all public and private
methods which should hopefully make their purpose clear.