### PR TITLE
Defend against global link styling

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -41,9 +41,10 @@
 		display: block;
 		position: relative;
 
-		a {
+		a:not(.o-typography-link) {
 			color: inherit;
 			text-decoration: underline;
+			border-bottom: 0;
 		}
 	}
 


### PR DESCRIPTION
Remy and I just found that n-ui-foundations globally styles links across
FT.com. This means that links inside a stepped progress component get a
double underline: one through text-decoration and one through borders.

This change ensures that globally-applied link styling doesn't interfere
with o-stepped-progress link styling, which is intentionally black with
an underline. If somebody wishes to override this we allow them to using
the standard `o-typography-link` class.