### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 
-import SteppedProgress from './src/js/stepped-progress';
+import SteppedProgress from './src/js/stepped-progress.js';
 
 const constructAll = function () {
 	SteppedProgress.init();

--- a/src/js/stepped-progress.js
+++ b/src/js/stepped-progress.js
@@ -1,5 +1,5 @@
 
-import SteppedProgressStep from './stepped-progress-step';
+import SteppedProgressStep from './stepped-progress-step.js';
 
 /**
  * Component class names.

--- a/test/stepped-progress-step.test.js
+++ b/test/stepped-progress-step.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as fixtures from './helpers/fixtures';
-import SteppedProgressStep from '../src/js/stepped-progress-step';
+import * as fixtures from './helpers/fixtures.js';
+import SteppedProgressStep from '../src/js/stepped-progress-step.js';
 
 describe('src/js/stepped-progress-step', () => {
 

--- a/test/stepped-progress.test.js
+++ b/test/stepped-progress.test.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as fixtures from './helpers/fixtures';
-import SteppedProgress from '../src/js/stepped-progress';
-import SteppedProgressStep from '../src/js/stepped-progress-step';
+import * as fixtures from './helpers/fixtures.js';
+import SteppedProgress from '../src/js/stepped-progress.js';
+import SteppedProgressStep from '../src/js/stepped-progress-step.js';
 
 sinon.assert.expose(proclaim, {
 	includeFail: false,


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing